### PR TITLE
Fix for issue #38: Fancy indexing on Dataset is not working with np.ndarray

### DIFF
--- a/formatter.py
+++ b/formatter.py
@@ -404,7 +404,7 @@ class CopyrightYearUpdater:
                     _contents = f.read()
                 except UnicodeDecodeError:
                     _timed_print(
-                        "Error reading file: ", _fname, verbose=self._flags["verbose"]
+                        f"Error reading file: {_fname}", verbose=self._flags["verbose"]
                     )
             _original = _contents[:]
             _contents = re.sub(self._regex_full, self._update_long_regex, _contents)

--- a/pydidas/core/dataset.py
+++ b/pydidas/core/dataset.py
@@ -162,7 +162,7 @@ class Dataset(ndarray):
             for _key in METADATA_KEYS
         }
         for _dim, _slicer in enumerate(self._meta["_get_item_key"]):
-            if isinstance(_slicer, ndarray) and _slicer.size == obj.size:
+            if isinstance(_slicer, ndarray) and _slicer.dtype == np.bool_ and _slicer.size == obj.size:
                 # in the case of a masked array, keep all axis keys.
                 break
             if isinstance(_slicer, Integral):

--- a/pydidas/core/dataset.py
+++ b/pydidas/core/dataset.py
@@ -162,7 +162,11 @@ class Dataset(ndarray):
             for _key in METADATA_KEYS
         }
         for _dim, _slicer in enumerate(self._meta["_get_item_key"]):
-            if isinstance(_slicer, ndarray) and _slicer.dtype == np.bool_ and _slicer.size == obj.size:
+            if (
+                isinstance(_slicer, ndarray)
+                and _slicer.dtype == np.bool_
+                and _slicer.size == obj.size
+            ):
                 # in the case of a masked array, keep all axis keys.
                 break
             if isinstance(_slicer, Integral):


### PR DESCRIPTION
Extended the if-statement with `_slicer.dtype == np.bool_` to fix it. 

```diff
diff --git a/pydidas/core/dataset.py b/pydidas/core/dataset.py
index 498bbff5..c030a23b 100644
--- a/pydidas/core/dataset.py
+++ b/pydidas/core/dataset.py
@@ -162,9 +162,9 @@ class Dataset(ndarray):
             for _key in METADATA_KEYS
         }
         for _dim, _slicer in enumerate(self._meta["_get_item_key"]):
-            if isinstance(_slicer, ndarray) and _slicer.size == obj.size:
+            if isinstance(_slicer, ndarray) and _slicer.dtype == np.bool_ and _slicer.size == obj.size:
                # in the case of a masked array, keep all axis keys.
                break
             if isinstance(_slicer, Integral):
```