### PR TITLE
Replace dropdown menu with checkbox for boolean choices

### DIFF
--- a/pydidas/gui/frames/composite_creator_frame.py
+++ b/pydidas/gui/frames/composite_creator_frame.py
@@ -136,9 +136,7 @@ class CompositeCreatorFrame(BaseFrameWithApp, SilxPlotWindowMixIn):
         ]:
             self.param_widgets[_key].io_edited.connect(self.__update_n_image)
 
-        self.param_widgets["use_roi"].io_edited.connect(
-            self.__toggle_roi_selection
-        )
+        self.param_widgets["use_roi"].io_edited.connect(self.__toggle_roi_selection)
         self.param_widgets["first_file"].io_edited.connect(self.__selected_first_file)
         self.param_widgets["hdf5_key"].io_edited.connect(self.__selected_hdf5_key)
         self.param_widgets["use_bg_file"].io_edited.connect(

--- a/pydidas/gui/frames/composite_creator_frame.py
+++ b/pydidas/gui/frames/composite_creator_frame.py
@@ -136,7 +136,7 @@ class CompositeCreatorFrame(BaseFrameWithApp, SilxPlotWindowMixIn):
         ]:
             self.param_widgets[_key].io_edited.connect(self.__update_n_image)
 
-        self.param_widgets["use_roi"].currentTextChanged.connect(
+        self.param_widgets["use_roi"].io_edited.connect(
             self.__toggle_roi_selection
         )
         self.param_widgets["first_file"].io_edited.connect(self.__selected_first_file)
@@ -146,10 +146,10 @@ class CompositeCreatorFrame(BaseFrameWithApp, SilxPlotWindowMixIn):
         )
         self.param_widgets["bg_file"].io_edited.connect(self.__selected_bg_file)
         self.param_widgets["bg_hdf5_key"].io_edited.connect(self.__selected_bg_hdf5_key)
-        self.param_widgets["use_thresholds"].currentTextChanged.connect(
+        self.param_widgets["use_thresholds"].io_edited.connect(
             self.__toggle_use_threshold
         )
-        self.param_widgets["use_detector_mask"].currentTextChanged.connect(
+        self.param_widgets["use_detector_mask"].io_edited.connect(
             self.__toggle_use_det_mask
         )
         # disconnect the generic param update connections and re-route to

--- a/pydidas/widgets/parameter_config/param_io_widget_checkbox.py
+++ b/pydidas/widgets/parameter_config/param_io_widget_checkbox.py
@@ -65,6 +65,7 @@ class ParamIoWidgetCheckBox(BaseParamIoWidgetMixIn, PydidasCheckBox):
         else:
             self.stateChanged.connect(self.emit_signal)
         self.set_value(param.value)
+        self.setText(param.name)
 
     def __convert_bool(self, value: Union[int, str]) -> bool:
         """
@@ -120,18 +121,6 @@ class ParamIoWidgetCheckBox(BaseParamIoWidgetMixIn, PydidasCheckBox):
         value : str
             The value to be set, "0" or "1".
         """
-        print(value)
         value = self.__convert_bool(value)
         self._old_value = value
         self.setChecked(value)
-
-    def set_param_name(self, name: str):
-        """
-        Set the name of the parameter.
-
-        Parameters
-        ----------
-        name : str
-            The name of the parameter.
-        """
-        self.setText(name)

--- a/pydidas/widgets/parameter_config/param_io_widget_checkbox.py
+++ b/pydidas/widgets/parameter_config/param_io_widget_checkbox.py
@@ -30,16 +30,15 @@ __all__ = ["ParamIoWidgetCheckBox"]
 
 from typing import Union
 
-from qtpy import QtCore
 import qtpy as __qtpy
 
 from ...core import Parameter
-from ...core.constants import POLICY_EXP_FIX
 from ..factory import PydidasCheckBox
 from .base_param_io_widget_mixin import BaseParamIoWidgetMixIn
 
 
 IS_QT6 = __qtpy.QT_VERSION[0] == "6"
+
 
 class ParamIoWidgetCheckBox(BaseParamIoWidgetMixIn, PydidasCheckBox):
     """Widgets for I/O during plugin parameter editing with boolean choices."""

--- a/pydidas/widgets/parameter_config/param_io_widget_checkbox.py
+++ b/pydidas/widgets/parameter_config/param_io_widget_checkbox.py
@@ -1,0 +1,138 @@
+# This file is part of pydidas.
+#
+# Copyright 2024, Helmholtz-Zentrum Hereon
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# pydidas is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# Pydidas is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Module with the ParamIoWidgetCheckBox class used to edit boolean Parameters.
+There are no typechecks implemented in the widget and any input which is
+accepted by the Parameter is valid.
+"""
+
+__author__ = "Nonni Heere"
+__copyright__ = "Copyright 2024, Helmholtz-Zentrum Hereon"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Malte Storm"
+__status__ = "Production"
+__all__ = ["ParamIoWidgetCheckBox"]
+
+from typing import Union
+
+from qtpy import QtCore
+import qtpy as __qtpy
+
+from ...core import Parameter
+from ...core.constants import POLICY_EXP_FIX
+from ..factory import PydidasCheckBox
+from .base_param_io_widget_mixin import BaseParamIoWidgetMixIn
+
+
+IS_QT6 = __qtpy.QT_VERSION[0] == "6"
+
+class ParamIoWidgetCheckBox(BaseParamIoWidgetMixIn, PydidasCheckBox):
+    """Widgets for I/O during plugin parameter editing with boolean choices."""
+
+    def __init__(self, param: Parameter, **kwargs: dict):
+        """
+        Initialize the widget.
+
+        Init method to set up the widget and set the links to the parameter
+        and Qt parent widget.
+
+        Parameters
+        ----------
+        param : Parameter
+            A Parameter instance.
+        width : int, optional
+            The width of the IOwidget.
+        """
+        PydidasCheckBox.__init__(self)
+        BaseParamIoWidgetMixIn.__init__(self, param, **kwargs)
+        param.value = self.__convert_bool(param.value)
+        if IS_QT6:
+            self.checkStateChanged.connect(self.emit_signal)
+        else:
+            self.stateChanged.connect(self.emit_signal)
+        self.set_value(param.value)
+
+    def __convert_bool(self, value: Union[int, str]) -> bool:
+        """
+        Convert boolean strings to bool.
+
+        This conversion is necessary because boolean "0" and "1" cannot be
+        interpreted as "True" and "False" straight away.
+
+        Parameters
+        ----------
+        value : Union[int, str]
+            The input value from the field. This could be any object.
+
+        Returns
+        -------
+        bool
+            The input value, with 0/1 converted to True or False
+        """
+        return True if value == "1" or value == 1 else False
+
+    def emit_signal(self):
+        """
+        Emit a signal that the value has been edited.
+
+        This method emits a signal that the combobox selection has been
+        changed and the Parameter value needs to be updated.
+        """
+        _cur_value = self.isChecked()
+        if _cur_value != self._old_value:
+            self._old_value = _cur_value
+            self.io_edited.emit("True" if _cur_value else "False")
+
+    def get_value(self) -> object:
+        """
+        Get the current value from the combobox to update the Parameter value.
+
+        Returns
+        -------
+        object
+            Bool value of the checkbox.
+        """
+        return self.isChecked()
+
+    def set_value(self, value: str):
+        """
+        Check or uncheck the checkbox.
+
+        This method is used to set the checkbox value.
+
+
+        Parameters
+        ----------
+        value : str
+            The value to be set, "0" or "1".
+        """
+        print(value)
+        value = self.__convert_bool(value)
+        self._old_value = value
+        self.setChecked(value)
+
+    def set_param_name(self, name: str):
+        """
+        Set the name of the parameter.
+
+        Parameters
+        ----------
+        name : str
+            The name of the parameter.
+        """
+        self.setText(name)

--- a/pydidas/widgets/parameter_config/parameter_widget.py
+++ b/pydidas/widgets/parameter_config/parameter_widget.py
@@ -194,11 +194,12 @@ class ParameterWidget(EmptyWidget):
             "linebreak": self._config["linebreak"],
         }
         if self.param.choices:
-            if set(self.param.choices) == {True, False}:
-                _widget = ParamIoWidgetCheckBox(self.param, **kwargs)
-                _widget.set_param_name(self.param.name)
-            else:
-                _widget = ParamIoWidgetComboBox(self.param, **kwargs)
+            _class = (
+                ParamIoWidgetCheckBox
+                if set(self.param.choices) == {True, False}
+                else ParamIoWidgetComboBox
+            )
+            _widget = _class(self.param, **kwargs)
         else:
             if self.param.dtype == Path:
                 _widget = ParamIoWidgetFile(self.param, **kwargs)

--- a/pydidas/widgets/parameter_config/parameter_widget.py
+++ b/pydidas/widgets/parameter_config/parameter_widget.py
@@ -42,6 +42,7 @@ from ...core.constants import (
 )
 from ...core.utils import convert_special_chars_to_unicode
 from ..factory import EmptyWidget, PydidasLabel
+from .param_io_widget_checkbox import ParamIoWidgetCheckBox
 from .param_io_widget_combo_box import ParamIoWidgetComboBox
 from .param_io_widget_file import ParamIoWidgetFile
 from .param_io_widget_hdf5key import ParamIoWidgetHdf5Key
@@ -84,7 +85,8 @@ class ParameterWidget(EmptyWidget):
         self.__store_config_from_kwargs(kwargs)
         self.__store_layout_args_for_widgets()
 
-        self.__create_name_widget()
+        if self.param.choices is None or set(self.param.choices) != {True, False}:
+            self.__create_name_widget()
         self.__create_param_io_widget()
         if self._config["width_unit"] > 0:
             self.__create_unit_widget()
@@ -192,7 +194,11 @@ class ParameterWidget(EmptyWidget):
             "linebreak": self._config["linebreak"],
         }
         if self.param.choices:
-            _widget = ParamIoWidgetComboBox(self.param, **kwargs)
+            if set(self.param.choices) == {True, False}:
+                _widget = ParamIoWidgetCheckBox(self.param, **kwargs)
+                _widget.set_param_name(self.param.name)
+            else:
+                _widget = ParamIoWidgetComboBox(self.param, **kwargs)
         else:
             if self.param.dtype == Path:
                 _widget = ParamIoWidgetFile(self.param, **kwargs)


### PR DESCRIPTION
If a parameter only has the choices True and False the dropdown menu is replaced by a checkbox to allow faster toggling between the values