### PR TITLE
Plugin to convert pyFAI integration output units to d-spacing in A or nm

### DIFF
--- a/pydidas/core/constants/__init__.py
+++ b/pydidas/core/constants/__init__.py
@@ -39,7 +39,7 @@ from .paths import *
 from .pyfai_names import *
 from .q_settings import *
 from .qt_presets import *
-from .unicode_greek_letters import *
+from .unicode_letters import *
 
 from . import image_ops
 
@@ -95,7 +95,7 @@ from . import qt_presets
 __all__.extend(qt_presets.__all__)
 del qt_presets
 
-from . import unicode_greek_letters
+from . import unicode_letters
 
-__all__.extend(unicode_greek_letters.__all__)
-del unicode_greek_letters
+__all__.extend(unicode_letters.__all__)
+del unicode_letters

--- a/pydidas/core/constants/unicode_letters.py
+++ b/pydidas/core/constants/unicode_letters.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 
 """
-The unicode_greek_letters module holds dictionaries to convert unicode Greek
+The unicode_letters module holds dictionaries to convert unicode
 letters to their ASCII names and vice versa.
 """
 
@@ -24,10 +24,10 @@ __copyright__ = "Copyright 2023 - 2024, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
-__all__ = ["GREEK_UNI_TO_ASCII", "GREEK_ASCII_TO_UNI"]
+__all__ = ["UNI_TO_ASCII", "ASCII_TO_UNI"]
 
 
-GREEK_UNI_TO_ASCII = {
+UNI_TO_ASCII = {
     "\u0391": "Alpha",
     "\u0392": "Beta",
     "\u0393": "Gamma",
@@ -77,7 +77,8 @@ GREEK_UNI_TO_ASCII = {
     "\u03c8": "psi",
     "\u03c9": "omega",
     "\u03b7": "eta",
+    "\u00c5": "Angstrom",
 }
 
 
-GREEK_ASCII_TO_UNI = dict(zip(GREEK_UNI_TO_ASCII.values(), GREEK_UNI_TO_ASCII.keys()))
+ASCII_TO_UNI = dict(zip(UNI_TO_ASCII.values(), UNI_TO_ASCII.keys()))

--- a/pydidas/core/generic_params/generic_params_fit.py
+++ b/pydidas/core/generic_params/generic_params_fit.py
@@ -30,7 +30,7 @@ __all__ = ["GENERIC_PARAMS_FIT"]
 
 from itertools import combinations
 
-from ..constants import GREEK_ASCII_TO_UNI
+from ..constants import ASCII_TO_UNI
 from .param_lists import FIT_OUTPUT_OPTIONS
 
 
@@ -39,7 +39,7 @@ GENERIC_PARAMS_FIT = (
         "fit_sigma_threshold": {
             "type": float,
             "default": 0.25,
-            "name": f"Fit {GREEK_ASCII_TO_UNI['sigma']} rejection threshold",
+            "name": f"Fit {ASCII_TO_UNI['sigma']} rejection threshold",
             "choices": None,
             "allow_None": False,
             "unit": "",
@@ -200,7 +200,7 @@ GENERIC_PARAMS_FIT = (
             "name": (
                 "Peak "
                 + (f"#{_num} " if _num != "" else "")
-                + f"fit {GREEK_ASCII_TO_UNI['sigma']} or {GREEK_ASCII_TO_UNI['Gamma']} "
+                + f"fit {ASCII_TO_UNI['sigma']} or {ASCII_TO_UNI['Gamma']} "
                 + "start guess"
             ),
             "choices": None,

--- a/pydidas/core/generic_params/generic_params_proc.py
+++ b/pydidas/core/generic_params/generic_params_proc.py
@@ -1,0 +1,45 @@
+# This file is part of pydidas.
+#
+# Copyright 2024, Helmholtz-Zentrum Hereon
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# pydidas is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# Pydidas is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+The generic_params_experiment module holds all the required data to create generic
+Parameters for the experiment context.
+"""
+
+__author__ = "Nonni Heere"
+__copyright__ = "Copyright 2024, Helmholtz-Zentrum Hereon"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Malte Storm"
+__status__ = "Production"
+__all__ = ["GENERIC_PARAMS_PROC"]
+
+from pydidas.core.constants import ASCII_TO_UNI
+
+
+GENERIC_PARAMS_PROC = {
+    "d_spacing_unit": {
+        "type": str,
+        "default": "Angstrom",
+        "name": "d-spacing unit",
+        "choices": ["Angstrom", "nm"],
+        "unit": "",
+        "allow_None": False,
+        "tooltip": (
+            f"The output d-spacing unit. {ASCII_TO_UNI['Angstrom']} for Angstroms and nm for nanometers."
+        ),
+    },
+}

--- a/pydidas/core/utils/str_utils.py
+++ b/pydidas/core/utils/str_utils.py
@@ -53,7 +53,7 @@ from typing import Union
 
 import numpy as np
 
-from ..constants import GREEK_ASCII_TO_UNI, GREEK_UNI_TO_ASCII
+from ..constants import ASCII_TO_UNI, UNI_TO_ASCII
 
 
 def get_fixed_length_str(
@@ -305,8 +305,8 @@ def convert_special_chars_to_unicode(obj: Union[str, list]) -> Union[str, list]:
     if isinstance(obj, str):
         _parts = obj.split()
         for _index, _part in enumerate(_parts):
-            if _part in GREEK_ASCII_TO_UNI.keys():
-                _parts[_index] = GREEK_ASCII_TO_UNI[_part]
+            if _part in ASCII_TO_UNI.keys():
+                _parts[_index] = ASCII_TO_UNI[_part]
         obj = " ".join(_parts)
         # insert Angstrom sign (in context of ^-1):
         obj = obj.replace("A^-1", "\u212b\u207b\u00b9")
@@ -338,8 +338,8 @@ def convert_unicode_to_ascii(obj: Union[str, list]) -> Union[str, list]:
     if isinstance(obj, str):
         _parts = obj.split()
         for _index, _part in enumerate(_parts):
-            if _part in GREEK_UNI_TO_ASCII:
-                _parts[_index] = GREEK_UNI_TO_ASCII[_part]
+            if _part in UNI_TO_ASCII:
+                _parts[_index] = UNI_TO_ASCII[_part]
         obj = " ".join(_parts)
         obj = obj.replace("\u212b", "A")
         obj = obj.replace("\u207b\u00b9", "^-1")

--- a/pydidas/plugins/pyfai_integration_base.py
+++ b/pydidas/plugins/pyfai_integration_base.py
@@ -41,7 +41,7 @@ from silx.opencl.common import OpenCL
 from ..contexts import DiffractionExperimentContext
 from ..core import UserConfigError, get_generic_param_collection
 from ..core.constants import (
-    GREEK_ASCII_TO_UNI,
+    ASCII_TO_UNI,
     PROC_PLUGIN,
     PROC_PLUGIN_IMAGE,
     pyFAI_METHOD,
@@ -58,7 +58,7 @@ logger = pydidas_logger()
 
 OCL = OpenCL()
 
-PI_STR = GREEK_ASCII_TO_UNI["pi"]
+PI_STR = ASCII_TO_UNI["pi"]
 
 
 class pyFAIintegrationBase(ProcPlugin):

--- a/pydidas/widgets/silx_plot/coordinate_transform_button.py
+++ b/pydidas/widgets/silx_plot/coordinate_transform_button.py
@@ -35,12 +35,12 @@ from silx.gui.plot.PlotToolButtons import PlotToolButton
 
 from ...contexts import DiffractionExperimentContext
 from ...core import UserConfigError
-from ...core.constants import GREEK_ASCII_TO_UNI
+from ...core.constants import ASCII_TO_UNI
 from ...resources import icons
 
 
-THETA = GREEK_ASCII_TO_UNI["theta"]
-CHI = GREEK_ASCII_TO_UNI["chi"]
+THETA = ASCII_TO_UNI["theta"]
+CHI = ASCII_TO_UNI["chi"]
 DIFFRACTION_EXP = DiffractionExperimentContext()
 
 

--- a/pydidas_plugins/proc_plugins/convert_to_d_spacing.py
+++ b/pydidas_plugins/proc_plugins/convert_to_d_spacing.py
@@ -37,7 +37,7 @@ from pydidas.core import (
     get_generic_param_collection,
     get_generic_parameter,
 )
-from pydidas.core.constants import PROC_PLUGIN, PROC_PLUGIN_IMAGE
+from pydidas.core.constants import PROC_PLUGIN, PROC_PLUGIN_INTEGRATED
 from pydidas.plugins import ProcPlugin
 
 
@@ -54,7 +54,7 @@ class ConvertToDSpacing(ProcPlugin):
     plugin_name = "Convert to d-spacing"
     basic_plugin = False
     plugin_type = PROC_PLUGIN
-    plugin_subtype = PROC_PLUGIN_IMAGE
+    plugin_subtype = PROC_PLUGIN_INTEGRATED
     default_params = get_generic_param_collection("d_spacing_unit")
     input_data_dim = -1
     output_data_dim = -1

--- a/pydidas_plugins/proc_plugins/convert_to_d_spacing.py
+++ b/pydidas_plugins/proc_plugins/convert_to_d_spacing.py
@@ -1,0 +1,107 @@
+# This file is part of pydidas.
+#
+# Copyright 2024, Helmholtz-Zentrum Hereon
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# pydidas is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# Pydidas is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Module with the PyFAI2dIntegration Plugin which allows to integrate diffraction
+patterns into a 2D radial/azimuthal map.
+"""
+
+__author__ = "Nonni Heere"
+__copyright__ = "Copyright 2024, Helmholtz-Zentrum Hereon"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Malte Storm"
+__status__ = "Production"
+__all__ = ["ConvertToDSpacing"]
+
+
+import numpy as np
+
+from pydidas.contexts import DiffractionExperimentContext
+from pydidas.core import Dataset, get_generic_param_collection, get_generic_parameter
+from pydidas.core.constants import PROC_PLUGIN, PROC_PLUGIN_IMAGE
+from pydidas.plugins import ProcPlugin
+
+
+class ConvertToDSpacing(ProcPlugin):
+    """
+    Convert Q, r or 2θ data from an integration plugin to d-spacing.
+
+    WARNING: pydidas is not yet capable of displaying non-uniform data.
+    """
+
+    plugin_name = "Convert to d-spacing"
+    basic_plugin = False
+    plugin_type = PROC_PLUGIN
+    plugin_subtype = PROC_PLUGIN_IMAGE
+    default_params = get_generic_param_collection("d_spacing_unit")
+    input_data_dim = -1
+    output_data_dim = -1
+
+    def __init__(self, *args, **kwargs):
+        self._EXP = kwargs.pop("diffraction_exp", DiffractionExperimentContext())
+        super().__init__(*args, **kwargs)
+
+    def pre_execute(self):
+        self._lambda = self._EXP.get_param_value("xray_wavelength")
+        self._detector_dist = self._EXP.get_param_value("detector_dist")
+
+    def execute(self, data: Dataset, **kwargs: dict) -> tuple[Dataset, dict]:
+        """
+        Convert Q, r, or 2θ data from an integration plugin to d-spacing.
+
+        Parameters:
+            data : pydidas.core.Dataset
+                The image / frame data.
+            **kwargs : dict
+                Any calling keyword arguments.
+
+        Returns:
+            data : pydidas.core.Dataset
+                The converted data.
+            kwargs : dict
+                Any calling kwargs, appended by any changes in the function.
+        """
+        for axis, label in data.axis_labels.items():
+            if (
+                f"{label} / {data.axis_units[axis]}"
+                in get_generic_parameter("rad_unit").choices
+            ):
+                _range = data.axis_ranges[axis]
+                match label:
+                    case "Q":
+                        if data.axis_units[axis] == "nm^-1":
+                            _range = _range / 10
+                        _range = (2 * np.pi) / _range
+                    case "r":
+                        _range = self._lambda / (
+                            2
+                            * np.sin(
+                                np.arctan(_range / (self._detector_dist * 1e3)) / 2
+                            )
+                        )
+                    case "2theta":
+                        if data.axis_units[axis] == "deg":
+                            _range = np.radians(_range)
+                        _range = self._lambda / (2 * np.sin(_range / 2))
+                if self.get_param_value("d_spacing_unit") == "nm":
+                    _range /= 10
+                    data.update_axis_unit(axis, "nm")
+                else:
+                    data.update_axis_unit(axis, "A")
+                data.update_axis_range(axis, _range)
+                data.update_axis_label(axis, "d-spacing")
+        return data, kwargs

--- a/tests/_plugin_tests/proc_plugins/test_convert_to_d_spacing.py
+++ b/tests/_plugin_tests/proc_plugins/test_convert_to_d_spacing.py
@@ -1,0 +1,128 @@
+# This file is part of pydidas.
+#
+# Copyright 2024, Helmholtz-Zentrum Hereon
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# pydidas is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# Pydidas is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for pydidas modules."""
+
+__author__ = "Nonni Heere"
+__copyright__ = "Copyright 2024, Helmholtz-Zentrum Hereon"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Malte Storm"
+__status__ = "Production"
+
+
+import unittest
+
+import numpy as np
+from qtpy import QtCore
+
+from pydidas.core import Dataset
+from pydidas.plugins import BasePlugin
+from pydidas.unittest_objects import LocalPluginCollection
+
+
+PLUGIN_COLLECTION = LocalPluginCollection()
+
+
+class TestConvertToDSpacing(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._lambda = 1.3
+        cls._detector_distance = 1.6
+
+    @classmethod
+    def tearDownClass(cls):
+        qs = QtCore.QSettings("Hereon", "pydidas")
+        qs.remove("unittesting")
+
+    def setUp(self):
+        self._data = Dataset(np.ones(8))
+        self._data.update_axis_range(0, (0, 10, 25, 325, -5, 2, 10000, 1e6))
+        self._ref_q = (2 * np.pi) / self._data.axis_ranges[0]
+        self._ref_r = self._lambda / (
+            2
+            * np.sin(
+                np.arctan(self._data.axis_ranges[0] / (self._detector_distance * 1e3))
+                / 2
+            )
+        )
+        self._ref_tdeg = self._lambda / (
+            2 * np.sin(np.radians(self._data.axis_ranges[0]) / 2)
+        )
+        self._ref_trad = self._lambda / (2 * np.sin(self._data.axis_ranges[0] / 2))
+
+    def test_creation(self):
+        plugin = PLUGIN_COLLECTION.get_plugin_by_name("ConvertToDSpacing")()
+        self.assertIsInstance(plugin, BasePlugin)
+
+    def test__execute_qnm(self):
+        plugin = PLUGIN_COLLECTION.get_plugin_by_name("ConvertToDSpacing")()
+        self._data.update_axis_label(0, "Q")
+        self._data.update_axis_unit(0, "nm^-1")
+        _result, _kwargs = plugin.execute(self._data)
+        self.assertEqual(_result.axis_labels[0], "d-spacing")
+        self.assertEqual(_result.axis_units[0], "A")
+        self.assertTrue(np.allclose(_result.axis_ranges[0], self._ref_q * 10))
+
+    def test__execute_qna(self):
+        plugin = PLUGIN_COLLECTION.get_plugin_by_name("ConvertToDSpacing")()
+        self._data.update_axis_label(0, "Q")
+        self._data.update_axis_unit(0, "A^-1")
+        _result, _kwargs = plugin.execute(self._data)
+        self.assertEqual(_result.axis_labels[0], "d-spacing")
+        self.assertEqual(_result.axis_units[0], "A")
+        self.assertTrue(np.allclose(_result.axis_ranges[0], self._ref_q))
+
+    def test__execute_rmm(self):
+        plugin = PLUGIN_COLLECTION.get_plugin_by_name("ConvertToDSpacing")()
+        self._data.update_axis_label(0, "r")
+        self._data.update_axis_unit(0, "mm")
+        plugin._lambda = self._lambda
+        plugin._detector_dist = self._detector_distance
+        _result, _kwargs = plugin.execute(self._data)
+        self.assertEqual(_result.axis_labels[0], "d-spacing")
+        self.assertEqual(_result.axis_units[0], "A")
+        self.assertTrue(np.allclose(_result.axis_ranges[0], self._ref_r))
+
+    def test__execute_tdeg(self):
+        plugin = PLUGIN_COLLECTION.get_plugin_by_name("ConvertToDSpacing")()
+        self._data.update_axis_label(0, "2theta")
+        self._data.update_axis_unit(0, "deg")
+        plugin._lambda = self._lambda
+        _result, _kwargs = plugin.execute(self._data)
+        self.assertEqual(_result.axis_labels[0], "d-spacing")
+        self.assertEqual(_result.axis_units[0], "A")
+        self.assertTrue(np.allclose(_result.axis_ranges[0], self._ref_tdeg))
+
+    def test__execute_trad(self):
+        plugin = PLUGIN_COLLECTION.get_plugin_by_name("ConvertToDSpacing")()
+        self._data.update_axis_label(0, "2theta")
+        self._data.update_axis_unit(0, "rad")
+        plugin._lambda = self._lambda
+        _result, _kwargs = plugin.execute(self._data)
+        self.assertEqual(_result.axis_labels[0], "d-spacing")
+        self.assertEqual(_result.axis_units[0], "A")
+        self.assertTrue(np.allclose(_result.axis_ranges[0], self._ref_trad))
+
+    def test__execute_output_nm(self):
+        plugin = PLUGIN_COLLECTION.get_plugin_by_name("ConvertToDSpacing")()
+        plugin.set_param_value("d_spacing_unit", "nm")
+        self._data.update_axis_label(0, "Q")
+        self._data.update_axis_unit(0, "nm^-1")
+        _result, _kwargs = plugin.execute(self._data)
+        self.assertEqual(_result.axis_labels[0], "d-spacing")
+        self.assertEqual(_result.axis_units[0], "nm")
+        self.assertTrue(np.allclose(_result.axis_ranges[0], self._ref_q))


### PR DESCRIPTION
A plugin to convert the output units by pyFAI integration plugins to d-spacing in A or nm.
Might fix #43 

Also adds Å to unicode_letters, making it not exclusive to greek letters.