### PR TITLE
Fix pyfai default azi range

### DIFF
--- a/.github/workflows/build_full_gh_pages.yml
+++ b/.github/workflows/build_full_gh_pages.yml
@@ -25,7 +25,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ref: ${{ github.head_ref }}
+        ref: ${{ github.ref }}
+    - name: Echo fetched ref
+      run: |
+        echo "Fetched ref: ${{ github.ref }}"
     - name: Set up Python
       uses: actions/setup-python@v3
       with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 .. SPDX-License-Identifier: CC0-1.0
 
 
+v24.mm.dd
+=========
+
+Improvements
+------------
+- Replaced the default azimuthal integration range to (-180, 180) or (0, 360)
+  respectively instead of None to have more consistent ranges (pyFAI issue #2291)
+
+
 v24.09.19
 =========
 

--- a/tests/plugins/test_pyfai_integration_base.py
+++ b/tests/plugins/test_pyfai_integration_base.py
@@ -204,13 +204,13 @@ class TestPyFaiIntegrationBase(unittest.TestCase):
     def test_get_azimuthal_range_native__no_range(self):
         plugin = pyFAIintegrationBase(azi_use_range="Full detector")
         _range = plugin.get_azimuthal_range_native()
-        self.assertIsNone(_range)
+        self.assertEqual(_range, (-180, 180))
 
     def test_get_azimuthal_range_native__no_azi_use_range_param(self):
         plugin = pyFAIintegrationBase(azi_use_range="Full detector")
         del plugin.params["azi_use_range"]
         _range = plugin.get_azimuthal_range_native()
-        self.assertIsNone(_range)
+        self.assertEqual(_range, (-180, 180))
 
     def test_get_azimuthal_range_native__equal_boundaries(self):
         plugin = pyFAIintegrationBase(
@@ -219,7 +219,7 @@ class TestPyFaiIntegrationBase(unittest.TestCase):
             azi_range_upper=12,
         )
         _range = plugin.get_azimuthal_range_native()
-        self.assertIsNone(_range)
+        self.assertEqual(_range, (-180, 180))
 
     def test_get_azimuthal_range_native__correct(self):
         _range = (12, 37)
@@ -234,7 +234,7 @@ class TestPyFaiIntegrationBase(unittest.TestCase):
     def test_get_azimuthal_range_in_deg__empty(self):
         plugin = pyFAIintegrationBase(azi_use_range="Full detector")
         _newrange = plugin.get_azimuthal_range_in_deg()
-        self.assertIsNone(_newrange)
+        self.assertEqual(_newrange, (-180, 180))
 
     def test_get_azimuthal_range_in_deg__degree_input(self):
         _range = (12, 37)
@@ -264,7 +264,7 @@ class TestPyFaiIntegrationBase(unittest.TestCase):
     def test_get_azimuthal_range_in_rad__empty(self):
         plugin = pyFAIintegrationBase(azi_use_range="Full detector")
         _newrange = plugin.get_azimuthal_range_in_rad()
-        self.assertIsNone(_newrange)
+        self.assertTrue(np.allclose(_newrange, (-np.pi, np.pi)))
 
     def test_get_azimuthal_range_in_rad__degree_input(self):
         _range = (12, 37)


### PR DESCRIPTION
Replaced the default azimuthal integration range to (-180, 180) or (0, 360) respectively instead of None to have more consistent ranges (https://github.com/silx-kit/pyFAI/issues/2291)