### PR TITLE
Added support for MacOS

### DIFF
--- a/src/pydidas/widgets/selection/directory_explorer.py
+++ b/src/pydidas/widgets/selection/directory_explorer.py
@@ -277,8 +277,10 @@ class _NetworkLocationFilterModel(QtCore.QSortFilterProxyModel):
             __prefix = "\\\\?\\Volume"
         elif platform.system() in ["Unix", "Linux"]:
             __prefix = "/dev/"
+        elif platform.system() == "Darwin":  # for macOS
+            __prefix = "/Volumes"
         else:
-            raise SystemError("Only windows and unix operating systems are supported!")
+            raise SystemError("Only Windows, Linux, and macOS operating systems are supported!")
         self.__network_drives = [
             _vol.rootPath()
             for _vol in __storage.mountedVolumes()


### PR DESCRIPTION
## Support for macOS in NetworkLocationFilterModel

## Summary
This PR introduces support for macOS in the `_NetworkLocationFilterModel` class. Previously, the class raised a `SystemError` for unsupported operating systems. With this update, it now supports macOS by adding `/Volumes` as the prefix for network locations.

## Changes
- Added macOS (`Darwin`) support by using `/Volumes` for network locations.
- Modified the system check for supported platforms, now correctly handling Windows, Linux, and macOS.

## Testing
The changes have been tested on macOS. However, the functionality on Windows and Linux has not been verified. I would appreciate feedback and additional testing on those platforms.

## Related Issues
- Fixes: Issue related to macOS support for network locations.

## Notes
- If further testing is needed on Windows/Linux, please run the app on those platforms to verify behavior.

