### PR TITLE
Fix pyfai missing units

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 .. SPDX-License-Identifier: CC0-1.0
 
 
+v25.mm.dd
+=========
+
+Improvements
+------------
+- Moved calculation of radial unit conversions to core.utils.scattering_geometry
+  module.
+
+Bugfixes
+--------
+- Fixed an issue when graphically selecting integration regions using "Q / A^-1"
+  or "2theta / rad" as units.
+
 v25.03.17
 =========
 

--- a/src/pydidas/contexts/diff_exp/diff_exp.py
+++ b/src/pydidas/contexts/diff_exp/diff_exp.py
@@ -166,6 +166,30 @@ class DiffractionExperiment(ObjectWithParameterCollection):
             and self.get_param_value("detector_npixy") > 0
         )
 
+    @property
+    def xray_wavelength_in_m(self) -> float:
+        """
+        Get the X-ray wavelength in meters.
+
+        Returns
+        -------
+        float
+            The wavelength in meters.
+        """
+        return self.get_param_value("xray_wavelength") * 1e-10
+
+    @property
+    def det_dist_in_m(self) -> float:
+        """
+        Get the detector distance in meters.
+
+        Returns
+        -------
+        float
+            The detector distance in meters.
+        """
+        return self.get_param_value("detector_dist")
+
     def as_pyfai_geometry(self) -> Geometry:
         """
         Get an equivalent pyFAI Geometry object.

--- a/src/pydidas/core/utils/__init__.py
+++ b/src/pydidas/core/utils/__init__.py
@@ -28,6 +28,7 @@ __status__ = "Production"
 
 
 # import __all__ items from modules:
+from . import scattering_geometry
 from .clipboard_ import *
 from .decorators import *
 from .file_checks import *

--- a/src/pydidas/core/utils/scattering_geometry.py
+++ b/src/pydidas/core/utils/scattering_geometry.py
@@ -29,7 +29,7 @@ from typing import Literal
 
 import numpy as np
 
-from pydidas.core import UserConfigError
+from pydidas.core.exceptions import UserConfigError
 
 
 def q_to_2theta(q: Real | np.ndarray, lambda_x: Real) -> Real | np.ndarray:

--- a/src/pydidas/core/utils/scattering_geometry.py
+++ b/src/pydidas/core/utils/scattering_geometry.py
@@ -15,7 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for pydidas modules."""
+"""
+The scattering_geometry module includes calculations required for conversions to/from Q.
+"""
 
 __author__ = "Malte Storm"
 __copyright__ = "Copyright 2025, Helmholtz-Zentrum Hereon"
@@ -23,6 +25,7 @@ __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
 __all__ = ["q_to_2theta", "convert_radial_value"]
+
 
 from numbers import Real
 from typing import Literal

--- a/src/pydidas/core/utils/scattering_geometry.py
+++ b/src/pydidas/core/utils/scattering_geometry.py
@@ -1,0 +1,106 @@
+# This file is part of pydidas.
+#
+# Copyright 2025, Helmholtz-Zentrum Hereon
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# pydidas is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# Pydidas is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for pydidas modules."""
+
+__author__ = "Malte Storm"
+__copyright__ = "Copyright 2025, Helmholtz-Zentrum Hereon"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Malte Storm"
+__status__ = "Production"
+__all__ = ["q_to_2theta", "convert_radial_value"]
+
+from numbers import Real
+from typing import Literal
+
+import numpy as np
+
+from pydidas.core import UserConfigError
+
+
+def q_to_2theta(q: Real | np.ndarray, lambda_x: Real) -> Real | np.ndarray:
+    """
+    Convert a q value to 2theta.
+
+    This function converts a q value (in inverse meters) to 2theta (in radian)
+
+    Parameters
+    ----------
+    q : Real | np.ndarray
+        The q value(s) to be converted.
+    lambda_x : Real
+        The X-ray wavelength in meters.
+
+    Returns
+    -------
+    Real | np.ndarray
+        The converted 2theta value(s).
+    """
+    return 2 * np.arcsin(lambda_x * q / (4 * np.pi))
+
+
+def convert_radial_value(
+    value: Real,
+    in_unit: Literal["2theta / deg", "2theta / rad", "Q / A^-1", "Q / nm^-1", "r / mm"],
+    out_unit: Literal[
+        "2theta / deg", "2theta / rad", "Q / A^-1", "Q / nm^-1", "r / mm"
+    ],
+    lambda_xray: Real,
+    det_dist: Real,
+) -> Real:
+    """
+    Convert a value from one unit to another.
+
+    Parameters
+    ----------
+    value : Real
+        The value to be converted.
+    in_unit : Literal["2theta / deg", "2theta / rad", "Q / A^-1", "Q / nm^-1", "r / mm"]
+        The unit of the input value.
+    out_unit : Literal["2theta / deg", "2theta / rad", "Q / A^-1", "Q / nm^-1", "r / mm"]
+        The unit to convert the value to.
+    lambda_xray : Real
+        The X-ray wavelength in meters.
+    det_dist : Real
+        The detector distance in meters.
+    """
+    if in_unit == out_unit:
+        return value
+
+    if in_unit == "2theta / deg":
+        value_in_2theta_rad = np.deg2rad(value)
+    elif in_unit == "2theta / rad":
+        value_in_2theta_rad = value
+    elif in_unit == "Q / A^-1":
+        value_in_2theta_rad = q_to_2theta(value * 1e10, lambda_xray)
+    elif in_unit == "Q / nm^-1":
+        value_in_2theta_rad = q_to_2theta(value * 1e9, lambda_xray)
+    elif in_unit == "r / mm":
+        value_in_2theta_rad = np.arctan(value * 1e-3 / det_dist)
+    else:
+        raise UserConfigError(f"The input unit `{in_unit}` is not supported.")
+    if out_unit == "2theta / deg":
+        return np.rad2deg(value_in_2theta_rad)
+    elif out_unit == "2theta / rad":
+        return value_in_2theta_rad
+    elif out_unit == "Q / A^-1":
+        return 4 * np.pi * np.sin(value_in_2theta_rad / 2) / lambda_xray * 1e-10
+    elif out_unit == "Q / nm^-1":
+        return 4 * np.pi * np.sin(value_in_2theta_rad / 2) / lambda_xray * 1e-9
+    elif out_unit == "r / mm":
+        return det_dist * np.tan(value_in_2theta_rad) * 1e3
+    raise UserConfigError(f"The output unit `{out_unit}` is not supported.")

--- a/src/pydidas/plugins/pyfai_integration_base.py
+++ b/src/pydidas/plugins/pyfai_integration_base.py
@@ -48,6 +48,7 @@ from pydidas.core.constants import (
     pyFAI_UNITS,
 )
 from pydidas.core.utils import pydidas_logger
+from pydidas.core.utils.scattering_geometry import convert_radial_value
 from pydidas.data_io import import_data
 from pydidas.plugins.base_proc_plugin import ProcPlugin
 
@@ -427,113 +428,58 @@ class pyFAIintegrationBase(ProcPlugin):
             )
         return None
 
-    def get_radial_range_as_r(self) -> None | tuple[float, float]:
+    def get_radial_range_in_units(self, unit: str) -> None | tuple[float, float]:
         """
-        Get the radial range as radius in mm.
-
-        Returns
-        -------
-        range :  None | tuple[float, float]
-            If no range has been set, returns None. Otherwise, the range limits are
-            given as tuple.
-        """
-        _range = self.get_radial_range_as_2theta(unit="rad")
-        if _range is None:
-            return None
-        _dist = self._EXP.get_param_value("detector_dist") * 1e3
-        return (_dist * np.tan(_range[0]), _dist * np.tan(_range[1]))
-
-    def get_radial_range_as_q(self) -> None | tuple[float, float]:
-        """
-        Get the radial range as q in nm^-1.
-
-        Returns
-        -------
-        range :  None | tuple[float, float]
-            If no range has been set, returns None. Otherwise, the range limits are
-            given as tuple.
-        """
-        _range = self.get_radial_range_as_2theta(unit="rad")
-        if _range is None:
-            return None
-        _lambda = self._EXP.get_param_value("xray_wavelength") * 1e-10
-        _q = (4 * np.pi / _lambda) * np.sin(np.asarray(_range) / 2) * 1e-9
-        return tuple(_q)
-
-    def get_radial_range_as_2theta(
-        self, unit: Literal["deg", "rad"] = "deg"
-    ) -> None | tuple[float, float]:
-        """
-        Get the radial range converted to 2 theta.
+        Get the radial range converted to the given unit.
 
         Parameters
         ----------
-        unit : Literal["deg", "rad"], optional
-            The unit of the range. Must be either "rad" or "deg". The default is "deg".
-
-        Returns
-        -------
-        range :  None | tuple[float, float]
-            If no range has been set, returns None. Otherwise, the range limits are
-            given as tuple.
+        unit : str
+            The new unit of the range.
         """
-        if self.get_param_value("rad_use_range", "Full detector") == "Full detector":
+        _range = self.get_radial_range()
+        if _range is None:
             return None
-        _low = self.get_param_value("rad_range_lower")
-        _high = self.get_param_value("rad_range_upper")
-        _unit = self.get_param_value("rad_unit")
-        _factor = np.pi / 180 if unit == "rad" else 1
-        if _unit == "Q / nm^-1":
-            _lambda = self._EXP.get_param_value("xray_wavelength") * 1e-10
-            _low = 180 / np.pi * 2 * np.arcsin((_low * 1e9 * _lambda) / (4 * np.pi))
-            _high = 180 / np.pi * 2 * np.arcsin((_high * 1e9 * _lambda) / (4 * np.pi))
-        elif _unit == "r / mm":
-            _dist = self._EXP.get_param_value("detector_dist")
-            _low = 180 / np.pi * np.arctan(_low * 1e-3 / _dist)
-            _high = 180 / np.pi * np.arctan(_high * 1e-3 / _dist)
-        return _low * _factor, _high * _factor
+        _range = convert_radial_value(
+            np.asarray(_range),
+            self.get_param_value("rad_unit"),
+            unit,
+            self._EXP.xray_wavelength_in_m,
+            self._EXP.det_dist_in_m,
+        )
+        return tuple(_range)
 
     def convert_radial_range_values(
         self,
-        from_unit: Literal["2theta / deg", "Q / nm^-1", "r / mm"],
-        to_unit: Literal["2theta / deg", "Q / nm^-1", "r / mm"],
+        from_unit: Literal[
+            "2theta / deg", "2theta / rad", "Q / A^-1", "Q / nm^-1", "r / mm"
+        ],
+        to_unit: Literal[
+            "2theta / deg", "2theta / rad", "Q / A^-1", "Q / nm^-1", "r / mm"
+        ],
     ):
         """
         Convert and store the radial range values from the given unit to the given unit.
 
         Parameters
         ----------
-        from_unit : Literal["2theta / deg", "Q / nm^-1", "r / mm"]
+        from_unit : Literal["2theta / deg", "2theta / rad", "Q / A^-1", "Q / nm^-1", "r / mm"]
             The previous unit.
-        to_unit : Literal["2theta / deg", "Q / nm^-1", "r / mm"]
+        to_unit : Literal["2theta / deg", "2theta / rad", "Q / A^-1", "Q / nm^-1", "r / mm"]
             The new unit.
         """
-        if from_unit == to_unit:
+        _range = self.get_radial_range()
+        if from_unit == to_unit or _range is None:
             return
-        _low = self.get_param_value("rad_range_lower")
-        _high = self.get_param_value("rad_range_upper")
-        _lambda = self._EXP.get_param_value("xray_wavelength") * 1e-10
-        _dist = self._EXP.get_param_value("detector_dist") * 1e3
-        if from_unit == "2theta / deg" and to_unit == "Q / nm^-1":
-            _low = (4 * np.pi / _lambda) * np.sin(_low * np.pi / 180 / 2) * 1e-9
-            _high = (4 * np.pi / _lambda) * np.sin(_high * np.pi / 180 / 2) * 1e-9
-        elif from_unit == "2theta / deg" and to_unit == "r / mm":
-            _low = _dist * np.tan(_low * np.pi / 180)
-            _high = _dist * np.tan(_high * np.pi / 180)
-        elif from_unit == "Q / nm^-1" and to_unit == "2theta / deg":
-            _low = 180 / np.pi * 2 * np.arcsin(1e9 * _low * _lambda / 4 / np.pi)
-            _high = 180 / np.pi * 2 * np.arcsin(1e9 * _high * _lambda / 4 / np.pi)
-        elif from_unit == "Q / nm^-1" and to_unit == "r / mm":
-            _low = _dist * np.tan(2 * np.arcsin(1e9 * _low * _lambda / 4 / np.pi))
-            _high = _dist * np.tan(2 * np.arcsin(1e9 * _high * _lambda / 4 / np.pi))
-        elif from_unit == "r / mm" and to_unit == "2theta / deg":
-            _low = 180 / np.pi * np.arctan(_low / _dist)
-            _high = 180 / np.pi * np.arctan(_high / _dist)
-        elif from_unit == "r / mm" and to_unit == "Q / nm^-1":
-            _low = (4 * np.pi / _lambda) * np.sin(np.arctan(_low / _dist) / 2) * 1e-9
-            _high = (4 * np.pi / _lambda) * np.sin(np.arctan(_high / _dist) / 2) * 1e-9
-        self.set_param_value("rad_range_lower", _low)
-        self.set_param_value("rad_range_upper", _high)
+        _range = convert_radial_value(
+            np.asarray(_range),
+            from_unit,
+            to_unit,
+            self._EXP.xray_wavelength_in_m,
+            self._EXP.det_dist_in_m,
+        )
+        self.set_param_value("rad_range_lower", _range[0])
+        self.set_param_value("rad_range_upper", _range[1])
 
 
 pyFAIintegrationBase.register_as_base_class()


### PR DESCRIPTION
Fix issue with missing unit conversions from Q / A^-1 and 2theta / rad in graphically selecting the  beamcenter.