### PR TITLE
Add pydidas imports

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Improvements
 - Moved calculation of radial unit conversions to core.utils.scattering_geometry
   module.
 - Added plugins for sin^2(chi) residual stress calculations.
+- Added importers/exporters for HDF5 formats for Scan, DiffractionExp and 
+  ProcessingTree.
+
 
 Bugfixes
 --------

--- a/src/pydidas/contexts/diff_exp/__init__.py
+++ b/src/pydidas/contexts/diff_exp/__init__.py
@@ -32,7 +32,7 @@ __status__ = "Production"
 # import __all__ items from modules:
 # even though not explicitly used, the import is necessary for python to read
 # the code and to register the classes in the metaclass registry
-from . import diff_exp_io_poni, diff_exp_io_yaml
+from . import diff_exp_io_hdf5, diff_exp_io_poni, diff_exp_io_yaml
 from .diff_exp import *
 from .diff_exp_context import *
 from .diff_exp_io import *
@@ -54,4 +54,5 @@ del (
     diff_exp_io_base,
     diff_exp_io_yaml,
     diff_exp_io_poni,
+    diff_exp_io_hdf5,
 )

--- a/src/pydidas/contexts/diff_exp/diff_exp_io_hdf5.py
+++ b/src/pydidas/contexts/diff_exp/diff_exp_io_hdf5.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2024 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2025, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -16,50 +16,56 @@
 # along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
 
 """
-Module with the DiffractionExperimentIoYaml class which is used to import or
-export DiffractionExperimentContext metadata from a YAML file.
+Module with the DiffractionExperimentIoHdf5 class which is used to import
+DiffractionExperimentContext metadata from HDF5 files (written by pydidas).
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2024 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2025, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
-__all__ = ["DiffractionExperimentIoYaml"]
+__all__ = ["DiffractionExperimentIoHdf5"]
 
-
-from numbers import Integral, Real
+from pathlib import Path
 from typing import Union
 
+import h5py
 import numpy as np
-import yaml
 
 from pydidas.contexts.diff_exp.diff_exp import DiffractionExperiment
 from pydidas.contexts.diff_exp.diff_exp_context import DiffractionExperimentContext
 from pydidas.contexts.diff_exp.diff_exp_io_base import DiffractionExperimentIoBase
 from pydidas.core import UserConfigError
-from pydidas.core.constants import LAMBDA_IN_A_TO_E, YAML_EXTENSIONS
+from pydidas.core.constants import HDF5_EXTENSIONS, LAMBDA_IN_A_TO_E
+from pydidas.core.utils import (
+    CatchFileErrors,
+)
+from pydidas.core.utils.hdf5_dataset_utils import (
+    export_context_to_hdf5,
+    read_and_decode_hdf5_dataset,
+)
 
 
 EXP = DiffractionExperimentContext()
 
 
-class DiffractionExperimentIoYaml(DiffractionExperimentIoBase):
+class DiffractionExperimentIoHdf5(DiffractionExperimentIoBase):
     """
-    YAML importer/exporter for ExperimentalSetting files.
+    Base class for WorkflowTree exporters.
     """
 
-    extensions = YAML_EXTENSIONS
-    format_name = "YAML"
+    extensions = HDF5_EXTENSIONS
+    format_name = "HDF5"
 
     @classmethod
-    def export_to_file(cls, filename: str, **kwargs: dict):
+    def export_to_file(cls, filename: Path | str, **kwargs: dict):
         """
-        Write the DiffractionExperiment to a file.
+        Write the ExperimentalTree to a pyFAI style poni file.
 
         Parameters
         ----------
-        filename : str
+        filename : Path | str
             The filename of the file to be written.
         diffraction_exp : DiffractionExperiment, optional
             The DiffractionExperiment instance to be exported. The default is the
@@ -67,41 +73,40 @@ class DiffractionExperimentIoYaml(DiffractionExperimentIoBase):
         """
         _EXP = kwargs.get("diffraction_exp", EXP)
         cls.check_for_existing_file(filename, **kwargs)
-        tmp_params = _EXP.get_param_values_as_dict()
-        # need to convert all float values to generic python "float" to
-        # allow using the yaml.save_dump function
-        for _key, _val in tmp_params.items():
-            if isinstance(_val, Real) and not isinstance(_val, Integral):
-                tmp_params[_key] = float(_val)
-        tmp_params["detector_mask_file"] = str(tmp_params["detector_mask_file"])
-        del tmp_params["xray_energy"]
-        with open(filename, "w") as stream:
-            yaml.safe_dump(tmp_params, stream)
+        export_context_to_hdf5(filename, _EXP, "entry/pydidas_config/diffraction_exp")
 
     @classmethod
     def import_from_file(
-        cls, filename: str, diffraction_exp: Union[DiffractionExperiment, None] = None
+        cls,
+        filename: Path | str,
+        diffraction_exp: Union[DiffractionExperiment, None] = None,
     ):
         """
         Restore the DiffractionExperimentContext from a YAML file.
 
         Parameters
         ----------
-        filename : str
+        filename : Path | str
             The filename of the file to be written.
         diffraction_exp : Union[DiffractionExperiment, None], optional
             The DiffractionExperiment instance to be updated.
         """
-        with open(filename, "r") as stream:
-            try:
-                cls.imported_params = yaml.safe_load(stream)
-            except yaml.YAMLError as yerr:
-                cls.imported_params = {}
-                raise yaml.YAMLError from yerr
-        if not isinstance(cls.imported_params, dict):
+        if diffraction_exp is None:
+            diffraction_exp = EXP
+        with (
+            CatchFileErrors(filename, KeyError, raise_file_read_error=False) as catcher,
+            h5py.File(filename, "r") as file,
+        ):
+            cls.imported_params = {}
+            for _key in diffraction_exp.params.keys():
+                cls.imported_params[_key] = read_and_decode_hdf5_dataset(
+                    file[f"entry/pydidas_config/diffraction_exp/{_key}"]
+                )
+        if catcher.raised_exception:
             raise UserConfigError(
                 f"Cannot interpret the selected file {filename} as a saved instance of "
-                "DiffractionExperimentContext."
+                "DiffractionExperimentContext. Please check the file format and "
+                "content."
             )
         cls.imported_params["xray_energy"] = LAMBDA_IN_A_TO_E / cls.imported_params.get(
             "xray_wavelength", np.nan

--- a/src/pydidas/contexts/diff_exp/diff_exp_io_hdf5.py
+++ b/src/pydidas/contexts/diff_exp/diff_exp_io_hdf5.py
@@ -52,7 +52,7 @@ EXP = DiffractionExperimentContext()
 
 class DiffractionExperimentIoHdf5(DiffractionExperimentIoBase):
     """
-    Base class for WorkflowTree exporters.
+    Importer / Exporter for DiffractionExperiment metadata from HDF5 files
     """
 
     extensions = HDF5_EXTENSIONS
@@ -61,7 +61,7 @@ class DiffractionExperimentIoHdf5(DiffractionExperimentIoBase):
     @classmethod
     def export_to_file(cls, filename: Path | str, **kwargs: dict):
         """
-        Write the ExperimentalTree to a pyFAI style poni file.
+        Write the ExperimentalTree to a HDF5 file.
 
         Parameters
         ----------
@@ -82,7 +82,7 @@ class DiffractionExperimentIoHdf5(DiffractionExperimentIoBase):
         diffraction_exp: Union[DiffractionExperiment, None] = None,
     ):
         """
-        Restore the DiffractionExperimentContext from a YAML file.
+        Restore the DiffractionExperimentContext from a HDF5 file.
 
         Parameters
         ----------

--- a/src/pydidas/contexts/diff_exp/diff_exp_io_poni.py
+++ b/src/pydidas/contexts/diff_exp/diff_exp_io_poni.py
@@ -52,7 +52,7 @@ class DiffractionExperimentIoPoni(DiffractionExperimentIoBase):
     @classmethod
     def export_to_file(cls, filename: str, **kwargs: dict):
         """
-        Write the ExperimentalTree to a pyFAI style poni file.
+        Write the DiffractionExperiment to a pyFAI style poni file.
 
         Parameters
         ----------

--- a/src/pydidas/contexts/scan/__init__.py
+++ b/src/pydidas/contexts/scan/__init__.py
@@ -31,7 +31,7 @@ __status__ = "Production"
 # import __all__ items from modules:
 # even though not explicitly used, the import is necessary for python to read
 # the code and to register the classes in the metaclass registry
-from . import scan_io_fio, scan_io_yaml
+from . import scan_io_fio, scan_io_hdf5, scan_io_yaml
 from .scan import *
 from .scan_context import *
 from .scan_io import *
@@ -41,4 +41,4 @@ from .scan_io_base import *
 __all__ = scan.__all__ + scan_context.__all__ + scan_io_base.__all__ + scan_io.__all__
 
 # Clean up the namespace:
-del scan, scan_context, scan_io_base, scan_io, scan_io_yaml
+del scan, scan_context, scan_io_base, scan_io, scan_io_yaml, scan_io_hdf5

--- a/src/pydidas/contexts/scan/scan_io_hdf5.py
+++ b/src/pydidas/contexts/scan/scan_io_hdf5.py
@@ -49,7 +49,7 @@ SCAN = ScanContext()
 
 class ScanIoHdf5(ScanIoBase):
     """
-    YAML importer/exporter for Scan objects.
+    HDF5 importer/exporter for Scan objects.
     """
 
     extensions = HDF5_EXTENSIONS
@@ -72,7 +72,7 @@ class ScanIoHdf5(ScanIoBase):
     @classmethod
     def import_from_file(cls, filename: str, scan: Union[Scan, None] = None):
         """
-        Restore the ScanContext from a YAML file.
+        Restore the ScanContext from a HDF5 file.
 
         Parameters
         ----------

--- a/src/pydidas/contexts/scan/scan_io_hdf5.py
+++ b/src/pydidas/contexts/scan/scan_io_hdf5.py
@@ -1,0 +1,103 @@
+# This file is part of pydidas.
+#
+# Copyright 2025, Helmholtz-Zentrum Hereon
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# pydidas is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# Pydidas is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Module with the ScanIoHdf5 class which is used to import and export
+ScanContext metadata from a HDF5 file.
+"""
+
+__author__ = "Malte Storm"
+__copyright__ = "Copyright 2025, Helmholtz-Zentrum Hereon"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Malte Storm"
+__status__ = "Production"
+__all__ = ["ScanIoHdf5"]
+
+
+from typing import Union
+
+import h5py
+
+from pydidas.contexts.scan.scan import Scan
+from pydidas.contexts.scan.scan_context import ScanContext
+from pydidas.contexts.scan.scan_io_base import ScanIoBase
+from pydidas.core import UserConfigError
+from pydidas.core.constants import HDF5_EXTENSIONS
+from pydidas.core.utils import CatchFileErrors
+from pydidas.core.utils.hdf5_dataset_utils import (
+    export_context_to_hdf5,
+    read_and_decode_hdf5_dataset,
+)
+
+
+SCAN = ScanContext()
+
+
+class ScanIoHdf5(ScanIoBase):
+    """
+    YAML importer/exporter for Scan objects.
+    """
+
+    extensions = HDF5_EXTENSIONS
+    format_name = "HDF5"
+
+    @classmethod
+    def export_to_file(cls, filename: str, **kwargs: dict):
+        """
+        Write the ScanTree to a file.
+
+        Parameters
+        ----------
+        filename : str
+            The filename of the file to be written.
+        """
+        _scan = kwargs.get("scan", SCAN)
+        cls.check_for_existing_file(filename, **kwargs)
+        export_context_to_hdf5(filename, _scan, "entry/pydidas_config/scan")
+
+    @classmethod
+    def import_from_file(cls, filename: str, scan: Union[Scan, None] = None):
+        """
+        Restore the ScanContext from a YAML file.
+
+        Parameters
+        ----------
+        filename : str
+            The filename of the file to be written.
+        scan : Union[None, pydidas.contexts.scan.Scan], optional
+            The Scan instance to be updated. If None, the ScanContext instance is used.
+            The default is None.
+        """
+
+        _scan = SCAN if scan is None else scan
+        with (
+            CatchFileErrors(filename, KeyError, raise_file_read_error=False) as catcher,
+            h5py.File(filename, "r") as file,
+        ):
+            cls.imported_params = {}
+            for _key in _scan.params.keys():
+                cls.imported_params[_key] = read_and_decode_hdf5_dataset(
+                    file[f"entry/pydidas_config/scan/{_key}"]
+                )
+        if catcher.raised_exception:
+            raise UserConfigError(
+                f"Cannot interpret the selected file {filename} as a saved instance of "
+                "DiffractionExperimentContext. Please check the file format and "
+                "content."
+            )
+        cls._verify_all_entries_present()
+        cls._write_to_scan_settings(scan=_scan)

--- a/src/pydidas/workflow/processing_tree_io/__init__.py
+++ b/src/pydidas/workflow/processing_tree_io/__init__.py
@@ -28,11 +28,16 @@ __maintainer__ = "Malte Storm"
 __status__ = "Production"
 
 
-from . import processing_tree_io_yaml
+from . import processing_tree_io_hdf5, processing_tree_io_yaml
 from .processing_tree_io_base import *
 from .processing_tree_io_meta import *
 
 
 __all__ = processing_tree_io_meta.__all__ + processing_tree_io_base.__all__
 
-del (processing_tree_io_base, processing_tree_io_meta, processing_tree_io_yaml)
+del (
+    processing_tree_io_base,
+    processing_tree_io_meta,
+    processing_tree_io_yaml,
+    processing_tree_io_hdf5,
+)

--- a/src/pydidas/workflow/processing_tree_io/processing_tree_io_hdf5.py
+++ b/src/pydidas/workflow/processing_tree_io/processing_tree_io_hdf5.py
@@ -1,0 +1,125 @@
+# This file is part of pydidas.
+#
+# Copyright 2025, Helmholtz-Zentrum Hereon
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# pydidas is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# Pydidas is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Module with the ProcessingTreeIoHdf5 class to import/export the WorkflowTree to HDF5.
+"""
+
+__author__ = "Malte Storm"
+__copyright__ = "Copyright 2025, Helmholtz-Zentrum Hereon"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Malte Storm"
+__status__ = "Production"
+__all__ = ["ProcessingTreeIoHdf5"]
+
+
+from pathlib import Path
+from typing import NewType
+
+import h5py
+
+from pydidas.core import UserConfigError
+from pydidas.core.constants import HDF5_EXTENSIONS
+from pydidas.core.utils import (
+    create_nx_dataset,
+    create_nx_entry_groups,
+    read_and_decode_hdf5_dataset,
+)
+from pydidas.version import VERSION
+from pydidas.workflow.processing_tree_io.processing_tree_io_base import (
+    ProcessingTreeIoBase,
+)
+
+
+ProcessingTree = NewType("ProcessingTree", type)
+
+
+class ProcessingTreeIoHdf5(ProcessingTreeIoBase):
+    """
+    Import/Export class for the ProcessingTree to/from HDF5 files.
+    """
+
+    extensions = HDF5_EXTENSIONS
+    format_name = "HDF5"
+
+    @classmethod
+    def export_to_file(cls, filename: Path | str, tree: ProcessingTree, **kwargs: dict):
+        """
+        Write the content to a file.
+
+        This method needs to be implemented by the concrete subclass.
+
+        Parameters
+        ----------
+        filename : Path | str
+            The filename of the file to be written.
+        tree : ProcessingTree
+            The workflow tree instance.
+        """
+        cls.check_for_existing_file(filename, **kwargs)
+        _group_name = "entry/pydidas_config"
+        with h5py.File(filename, "a") as _file:
+            create_nx_entry_groups(_file, _group_name, group_type="NXcollection")
+            create_nx_dataset(_file[_group_name], "workflow", tree.export_to_string())
+            create_nx_dataset(_file[_group_name], "pydidas_version", VERSION)
+
+    @classmethod
+    def import_from_file(cls, filename: Path | str) -> ProcessingTree:
+        """
+        Restore the content from a file.
+
+        This method needs to be implemented by the concrete subclass.
+
+        Parameters
+        ----------
+        filename : Path | str
+            The filename of the file to be written.
+
+        Returns
+        -------
+        ProcessingTree
+            The restored ProcessingTree.
+        """
+        from pydidas.workflow.processing_tree import ProcessingTree
+
+        _version = "23.7.5 or earlier"
+
+        with h5py.File(filename, "r") as _file:
+            try:
+                _tree_repr = read_and_decode_hdf5_dataset(
+                    _file["entry/pydidas_config/workflow"]
+                )
+                _version = read_and_decode_hdf5_dataset(
+                    _file["entry/pydidas_config/pydidas_version"]
+                )
+                _tree = ProcessingTree()
+                _tree.restore_from_string(_tree_repr)
+            except (KeyError, TypeError, UserConfigError, ValueError, NameError):
+                if _version < VERSION:
+                    raise UserConfigError(
+                        "Import of ProcessingTree was not successful. \n\n"
+                        "The selected file does not include a workflow tree "
+                        "configuration or the ProcessingTree was created with "
+                        f"version {_version} and could not be imported in the "
+                        f"current version ({VERSION})."
+                    )
+                raise UserConfigError(
+                    "Could not import the Workflow from the given file:"
+                    f"\n    {filename}\nPlease check that the content of the file "
+                    "is a Pydidas ProcessingTree."
+                )
+        return _tree

--- a/src/pydidas/workflow/result_io/processing_result_io_hdf5.py
+++ b/src/pydidas/workflow/result_io/processing_result_io_hdf5.py
@@ -168,7 +168,7 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
 
         Parameters
         ----------
-        save_dir : Path | Str
+        save_dir : Path | str
             The full path for the data to be saved.
         node_information : dict
             A dictionary with nodeID keys and dictionary values. Each value dictionary
@@ -329,7 +329,7 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
             The result dictionary with nodeID keys and result values.
         scan_context : Scan |None, optional
             The scan context to be used for exporting to file. If None, the
-            global scan context will be use. The default is None.
+            global scan context will be used. The default is None.
         kwargs : dict
             Any kwargs which should be passed to the underlying exporter.
         """
@@ -408,7 +408,7 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
 
         Parameters
         ----------
-        filename : Path | Str
+        filename : Path | str
             The full filename of the file to be imported.
 
         Returns

--- a/tests/contexts/diff_exp/test_diff_exp_io_hdf5.py
+++ b/tests/contexts/diff_exp/test_diff_exp_io_hdf5.py
@@ -1,0 +1,144 @@
+# This file is part of pydidas.
+#
+# Copyright 2025, Helmholtz-Zentrum Hereon
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# pydidas is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# Pydidas is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for pydidas modules."""
+
+__author__ = "Malte Storm"
+__copyright__ = "Copyright 2025, Helmholtz-Zentrum Hereon"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Malte Storm"
+__status__ = "Production"
+
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+import pytest
+
+from pydidas.contexts import DiffractionExperimentContext
+from pydidas.contexts.diff_exp import DiffractionExperiment
+from pydidas.contexts.diff_exp.diff_exp_io_hdf5 import DiffractionExperimentIoHdf5
+from pydidas.core import UserConfigError
+from pydidas.core.utils import create_nx_entry_groups, get_random_string
+from pydidas.core.utils.hdf5_dataset_utils import (
+    export_context_to_hdf5,
+    read_and_decode_hdf5_dataset,
+)
+
+
+EXP = DiffractionExperimentContext()
+EXP_IO_HDF5 = DiffractionExperimentIoHdf5
+
+
+@pytest.fixture(scope="module")
+def temp_dir() -> Path:
+    """Fixture to create a temporary directory."""
+    temp_dir = tempfile.mkdtemp()
+    yield Path(temp_dir)
+    shutil.rmtree(temp_dir)
+
+
+@pytest.fixture
+def modify_diffraction_exp_context(temp_dir) -> dict[str, Any]:
+    """Fixture to modify the DiffractionExperimentContext."""
+    _randomize_diffraction_exp(EXP, temp_dir)
+    yield {_key: _param.value_for_export for _key, _param in EXP.params.items()}
+    EXP.restore_all_defaults(True)
+
+
+def _randomize_diffraction_exp(exp: DiffractionExperiment, local_dir: Path):
+    for _key, _param in exp.params.items():
+        if _key in ["detector_npixx", "detector_npixy"]:
+            _val = int(1000 * np.random.rand()) + 5
+        elif _key in ["detector_mask_file"]:
+            _val = local_dir / "mask.tif"
+        elif _key in ["detector_name"]:
+            _val = get_random_string(6)
+        else:
+            _val = np.round(0.5 + 5 * np.random.rand(), decimals=5)
+        exp.set_param_value(_key, _val)
+
+
+@pytest.fixture
+def create_hdf5_file(temp_dir) -> Path:
+    """Fixture to create a temporary HDF5 file."""
+    hdf5_filename = temp_dir / "diffraction_exp_io_hdf5.h5"
+    export_context_to_hdf5(hdf5_filename, EXP, "entry/pydidas_config/diffraction_exp")
+    return hdf5_filename
+
+
+def test_export_to_file__correct(modify_diffraction_exp_context, temp_dir):
+    """Test the export_to_file method."""
+    hdf5_file = temp_dir / "diffraction_exp_io_hdf5.h5"
+    EXP_IO_HDF5.export_to_file(hdf5_file)
+    with h5py.File(hdf5_file, "r") as file:
+        _group = file["entry/pydidas_config/diffraction_exp"]
+        for _key, _param in EXP.params.items():
+            assert (
+                read_and_decode_hdf5_dataset(_group[_key])
+                == modify_diffraction_exp_context[_key]
+            )
+
+
+def test_export_to_file__w_diffraction_exp(temp_dir):
+    """Test the export_to_file method with a custom DiffractionExperiment."""
+    local_EXP = DiffractionExperiment()
+    _randomize_diffraction_exp(local_EXP, temp_dir)
+    hdf5_file = temp_dir / "local_diffraction_exp_io_hdf5.h5"
+    EXP_IO_HDF5.export_to_file(hdf5_file, diffraction_exp=local_EXP)
+    with h5py.File(hdf5_file, "r") as file:
+        _group = file["entry/pydidas_config/diffraction_exp"]
+        for _key, _param in EXP.params.items():
+            assert (
+                read_and_decode_hdf5_dataset(_group[_key])
+                == local_EXP.params[_key].value_for_export
+            )
+
+
+def test_import_from_file__empty_file(temp_dir):
+    _fname = temp_dir / "empty_file.h5"
+    with h5py.File(_fname, "w") as file:
+        create_nx_entry_groups(
+            file, "entry/pydidas_config/diffraction_exp", group_type="NXcollection"
+        )
+    with pytest.raises(UserConfigError):
+        EXP_IO_HDF5.import_from_file(_fname)
+
+
+def test_import_from_file(temp_dir, modify_diffraction_exp_context, create_hdf5_file):
+    """Test the import_from_file method."""
+    EXP_IO_HDF5.import_from_file(create_hdf5_file)
+    for _key, _param in EXP.params.items():
+        assert EXP.params[_key].value_for_export == modify_diffraction_exp_context[_key]
+
+
+def test_import_from_file__to_local_context(
+    temp_dir, modify_diffraction_exp_context, create_hdf5_file
+):
+    """Test the import_from_file method."""
+    local_EXP = DiffractionExperiment()
+    EXP_IO_HDF5.import_from_file(create_hdf5_file, diffraction_exp=local_EXP)
+    for _key, _param in local_EXP.params.items():
+        assert EXP.params[_key].value_for_export == modify_diffraction_exp_context[_key]
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/contexts/scan/test_scan_io_hdf5.py
+++ b/tests/contexts/scan/test_scan_io_hdf5.py
@@ -1,0 +1,167 @@
+# This file is part of pydidas.
+#
+# Copyright 2025, Helmholtz-Zentrum Hereon
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# pydidas is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# Pydidas is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for pydidas modules."""
+
+__author__ = "Malte Storm"
+__copyright__ = "Copyright 2025, Helmholtz-Zentrum Hereon"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Malte Storm"
+__status__ = "Production"
+
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+import pytest
+
+from pydidas.contexts import Scan, ScanContext
+from pydidas.contexts.scan.scan_io_hdf5 import ScanIoHdf5
+from pydidas.core import UserConfigError
+from pydidas.core.utils import create_nx_entry_groups, get_random_string
+from pydidas.core.utils.hdf5_dataset_utils import (
+    export_context_to_hdf5,
+    read_and_decode_hdf5_dataset,
+)
+
+
+SCAN = ScanContext()
+SCAN_IO_HDF5 = ScanIoHdf5
+
+PARAMS_WITH_INT = [
+    "scan_dim0_n_points",
+    "scan_dim1_n_points",
+    "scan_dim2_n_points",
+    "scan_dim3_n_points",
+    "scan_start_index",
+    "scan_multiplicity",
+    "scan_index_stepping",
+]
+PARAMS_WITH_STR = [
+    "scan_dim0_label",
+    "scan_dim0_unit",
+    "scan_dim1_label",
+    "scan_dim1_unit",
+    "scan_dim2_label",
+    "scan_dim2_unit",
+    "scan_dim3_label",
+    "scan_dim3_unit",
+    "scan_name_pattern",
+    "scan_base_directory",
+    "scan_title",
+]
+
+
+@pytest.fixture(scope="module")
+def temp_dir() -> Path:
+    """Fixture to create a temporary directory."""
+    temp_dir = tempfile.mkdtemp()
+    yield Path(temp_dir)
+    shutil.rmtree(temp_dir)
+
+
+@pytest.fixture
+def modify_scan_context(temp_dir) -> dict[str, Any]:
+    """Fixture to modify the DiffractionExperimentContext."""
+    _randomize_scan(SCAN, temp_dir)
+    yield {_key: _param.value_for_export for _key, _param in SCAN.params.items()}
+    SCAN.restore_all_defaults(True)
+
+
+def _randomize_scan(scan: Scan, local_dir: Path):
+    for _key, _param in scan.params.items():
+        if _key in PARAMS_WITH_INT:
+            _val = int(1000 * np.random.rand()) + 5
+        elif _key in PARAMS_WITH_STR:
+            _val = get_random_string(6)
+        elif _key == "scan_dim":
+            _val = np.random.randint(1, 5)
+        elif _key == "scan_multi_image_handling":
+            _val = np.random.choice(["Average", "Sum", "Maximum"])
+        else:
+            _val = np.round(0.5 + 5 * np.random.rand(), decimals=5)
+        scan.set_param_value(_key, _val)
+
+
+@pytest.fixture
+def create_hdf5_file(temp_dir) -> Path:
+    """Fixture to create a temporary HDF5 file."""
+    hdf5_filename = temp_dir / "scan_io_hdf5.h5"
+    export_context_to_hdf5(hdf5_filename, SCAN, "entry/pydidas_config/scan")
+    return hdf5_filename
+
+
+def test_export_to_file__correct(modify_scan_context, temp_dir):
+    """Test the export_to_file method."""
+    hdf5_file = temp_dir / "scan_io_hdf5.h5"
+    SCAN_IO_HDF5.export_to_file(hdf5_file)
+    with h5py.File(hdf5_file, "r") as file:
+        _group = file["entry/pydidas_config/scan"]
+        for _key, _param in SCAN.params.items():
+            assert (
+                read_and_decode_hdf5_dataset(_group[_key]) == modify_scan_context[_key]
+            )
+
+
+def test_export_to_file__w_scan(temp_dir):
+    """Test the export_to_file method with a custom Scan."""
+    local_SCAN = Scan()
+    _randomize_scan(local_SCAN, temp_dir)
+    hdf5_file = temp_dir / "local_scan_io_hdf5.h5"
+    SCAN_IO_HDF5.export_to_file(hdf5_file, scan=local_SCAN)
+    with h5py.File(hdf5_file, "r") as file:
+        _group = file["entry/pydidas_config/scan"]
+        for _key, _param in SCAN.params.items():
+            assert (
+                read_and_decode_hdf5_dataset(_group[_key])
+                == local_SCAN.params[_key].value_for_export
+            )
+
+
+def test_import_from_file__empty_file(temp_dir):
+    _fname = temp_dir / "empty_file.h5"
+    with h5py.File(_fname, "w") as file:
+        create_nx_entry_groups(
+            file, "entry/pydidas_config/scan", group_type="NXcollection"
+        )
+    with pytest.raises(UserConfigError):
+        SCAN_IO_HDF5.import_from_file(_fname)
+
+
+def test_import_from_file(temp_dir, modify_scan_context, create_hdf5_file):
+    """Test the import_from_file method."""
+    SCAN_IO_HDF5.import_from_file(create_hdf5_file)
+    for _key, _param in SCAN.params.items():
+        assert SCAN.params[_key].value_for_export == modify_scan_context[_key]
+
+
+def test_import_from_file__to_local_context(
+    temp_dir, modify_scan_context, create_hdf5_file
+):
+    """Test the import_from_file method."""
+    local_SCAN = Scan()
+    SCAN_IO_HDF5.import_from_file(create_hdf5_file, scan=local_SCAN)
+    for _key, _param in local_SCAN.params.items():
+        assert SCAN.params[_key].value_for_export == modify_scan_context[_key]
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/workflow/workflow_tree_io/test_workflow_tree_io_hdf5.py
+++ b/tests/workflow/workflow_tree_io/test_workflow_tree_io_hdf5.py
@@ -1,0 +1,125 @@
+# This file is part of pydidas.
+#
+# Copyright 2025, Helmholtz-Zentrum Hereon
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# pydidas is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# Pydidas is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for pydidas modules."""
+
+__author__ = "Malte Storm"
+__copyright__ = "Copyright 2025, Helmholtz-Zentrum Hereon"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Malte Storm"
+__status__ = "Production"
+
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import h5py
+import pytest
+
+import pydidas
+from pydidas.core import UserConfigError
+from pydidas.core.utils import read_and_decode_hdf5_dataset
+from pydidas.workflow import ProcessingTree, WorkflowTree
+from pydidas.workflow.processing_tree_io.processing_tree_io_hdf5 import (
+    ProcessingTreeIoHdf5,
+)
+
+
+PLUGIN_COLL = pydidas.plugins.PluginCollection()
+
+
+@pytest.fixture(scope="module")
+def temp_dir() -> Path:
+    """Fixture to create a temporary directory."""
+    temp_dir = tempfile.mkdtemp()
+    yield Path(temp_dir)
+    shutil.rmtree(temp_dir)
+
+
+@pytest.fixture
+def test_tree() -> ProcessingTree:
+    """Fixture to create a test ProcessingTree."""
+    _pluginclass = PLUGIN_COLL.get_plugin_by_name("PyFAIazimuthalIntegration")
+    _plugin = _pluginclass()
+    _tree = WorkflowTree()
+    _tree.clear()
+    _tree.create_and_add_node(_plugin)
+    _tree.create_and_add_node(_plugin)
+    _tree.create_and_add_node(_plugin, parent=_tree.nodes[0])
+    return _tree
+
+
+def export_to_file(filename: Path | str, tree: ProcessingTree):
+    with h5py.File(filename, "a") as _file:
+        _entry = _file.create_group("entry")
+        _config = _entry.create_group("pydidas_config")
+        _config.create_dataset("workflow", data=tree.export_to_string())
+        _config.create_dataset("pydidas_version", data=pydidas.VERSION)
+
+
+def test_export_to_file(temp_dir, test_tree):
+    _filename = temp_dir / "test_export.hdf5"
+    ProcessingTreeIoHdf5.export_to_file(_filename, test_tree, overwrite=True)
+    with h5py.File(_filename, "r") as f:
+        _tree_repr = read_and_decode_hdf5_dataset(f["entry/pydidas_config/workflow"])
+        _version = read_and_decode_hdf5_dataset(
+            f["entry/pydidas_config/pydidas_version"]
+        )
+    assert _tree_repr == test_tree.export_to_string()
+    assert _version == pydidas.VERSION
+
+
+def test_import_from_file__w_version(temp_dir, test_tree):
+    _filename = temp_dir / "test_import.hdf5"
+    export_to_file(_filename, test_tree)
+    _new = ProcessingTreeIoHdf5.import_from_file(_filename)
+    assert set(_new.nodes) == set(test_tree.nodes)
+    for _id, _node in _new.nodes.items():
+        assert set(_node.plugin.params) == set(test_tree.nodes[_id].plugin.params)
+
+
+def test_import_from_file__w_version_and_error(temp_dir):
+    _filename = temp_dir / "test_incorrect_import.hdf5"
+    with h5py.File(_filename, "w") as _f:
+        _f["entry/pydidas_config/workflow"] = "1234"
+    with pytest.raises(UserConfigError):
+        ProcessingTreeIoHdf5.import_from_file(_filename)
+
+
+def test_import_from_file__old_version_no_error(temp_dir, test_tree):
+    _filename = temp_dir / "test_old_version_import.hdf5"
+    export_to_file(_filename, test_tree)
+    with h5py.File(_filename, "a") as _f:
+        _f["entry/pydidas_config/pydidas_verion"] = "0.0.0"
+    _new = ProcessingTreeIoHdf5.import_from_file(_filename)
+    assert set(_new.nodes) == set(test_tree.nodes)
+    for _id, _node in _new.nodes.items():
+        assert set(_node.plugin.params) == set(test_tree.nodes[_id].plugin.params)
+
+
+def test_import_from_file__old_version_w_error(temp_dir):
+    _filename = temp_dir / "test_old_version_import.hdf5"
+    with h5py.File(_filename, "w") as _f:
+        _f["entry/pydidas_config/pydidas_verion"] = "0.0.0"
+        _f["entry/pydidas_config/workflow"] = "1234"
+    with pytest.raises(UserConfigError):
+        ProcessingTreeIoHdf5.import_from_file(_filename)
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
Add imports (and exports) for context objects like Scan, DiffractionExp and WorkflowTree in HDF5 format.
This also allows to import these contexts directly from results written in pydidas.