### PR TITLE
Release version 25.04.08

### DIFF
--- a/.github/workflows/release_new_version.yml
+++ b/.github/workflows/release_new_version.yml
@@ -153,15 +153,15 @@ jobs:
             ref: "refs/tags/v${{ needs.check_if_new_version.outputs.version_number }}",
           });
 
-  publish_to_pypi_test:
+  publish_to_pypi:
     runs-on: ubuntu-latest
     needs:
       - check_if_new_version
       - add_python_wheel_to_release
     if: needs.check_if_new_version.outputs.is_new_version == 'true'
     environment:
-      name: testpypi
-      url: https:/test.pypi.org/p/pydidas
+      name: pypi
+      url: https:/pypi.org/p/pydidas
     permissions:
       id-token: write
     steps:
@@ -179,7 +179,5 @@ jobs:
         with:
           name: python-package-distribution
           path: dist/
-      - name: Publish package distributions to TestPyPI
+      - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release_new_version.yml
+++ b/.github/workflows/release_new_version.yml
@@ -161,7 +161,7 @@ jobs:
     if: needs.check_if_new_version.outputs.is_new_version == 'true'
     environment:
       name: pypi
-      url: https:/pypi.org/p/pydidas
+      url: https://pypi.org/p/pydidas
     permissions:
       id-token: write
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 .. SPDX-License-Identifier: CC0-1.0
 
 
-v25.mm.dd
+v25.04.08
 =========
 
 Improvements
@@ -34,7 +34,7 @@ Bugfixes
 - Fixed an issue which occured when running workflows with no nodes with results.
 - Fixed an issue where selecting a filename would introduce a trailing space.
 - Fixed missing Parameters for output formats and overwriting in WorkflowRunFrame
-
+- Fixed an issue in the pyFAI names where the LUT entries were missing.
 
 v25.03.17
 =========

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,8 +26,8 @@ identifiers:
   - description: The pydidas project DOI
     type: doi
     value: "10.5281/zenodo.7568610"
-date-released: 2025-03-17
-version: 25.03.17
+date-released: 2025-04-08
+version: 25.04.08
 funding:
   - funder: Deutsche Forschungsgemeinschaft (DFG)
     grant: 460248799

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ There is no need to prepare the environment further.
 You will require a pydidas wheel file to install it using pip. If you have not
 downloaded a build wheel file, you need to prepare one prior to installation.
 
+### Using pip
+Pydidas is available on PyPI and can be installed simply with 
+
+    python -m pip install pydidas
+
 #### Using a python wheel
 
 Wheels for pydidas are available on the 

--- a/pydidas/version.py
+++ b/pydidas/version.py
@@ -23,7 +23,7 @@ Module with the pydidas Version number.
 __author__ = "Malte Storm"
 __copyright__ = "Copyright 2024 - 2025, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
-__version__ = "25.03.17"
+__version__ = "25.04.08"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # Copyright 2024 - 2025, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: CC0-1.0
 
-pyFAI==2024.9.0
+pyFAI==2025.3.0
 scikit-image>=0.22.0
 sphinx>=8.0.0
 pydata_sphinx_theme>=0.15.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -106,7 +106,7 @@ platformdirs==4.3.2
     #   pytools
 pydata-sphinx-theme==0.15.4
     # via -r requirements.in
-pyfai==2024.9.0
+pyfai==2025.3.0
     # via -r requirements.in
 pygments==2.18.0
     # via

--- a/src/pydidas/core/constants/pyfai_names.py
+++ b/src/pydidas/core/constants/pyfai_names.py
@@ -56,10 +56,10 @@ pyFAI_METHOD = {
     "CSR OpenCL": ("bbox", "csr", "opencl"),
     "CSR full": ("full", "csr", "cython"),
     "CSR full OpenCL": ("full", "csr", "opencl"),
-    "CSC": ("bbox", "csc", "cython"),
-    "CSC OpenCL": ("bbox", "csc", "opencl"),
-    "CSC full": ("full", "csc", "cython"),
-    "CSC full OpenCL": ("full", "csc", "opencl"),
+    "LUT": ("bbox", "lut", "cython"),
+    "LUT OpenCL": ("bbox", "lut", "opencl"),
+    "LUT full": ("full", "lut", "cython"),
+    "LUT full OpenCL": ("full", "lut", "opencl"),
 }
 
 

--- a/src/pydidas/version.py
+++ b/src/pydidas/version.py
@@ -23,7 +23,7 @@ Module with the pydidas Version number.
 __author__ = "Malte Storm"
 __copyright__ = "Copyright 2024 - 2025, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
-__version__ = "25.03.17"
+__version__ = "25.04.08"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
 


### PR DESCRIPTION
Changelog for version 25.04.08:
- Some bugfixed (particularly in testing workflows)
- Added plugin to import 1d HDF5 profiles
- Added importers/exporters for HDF5 formats for Scan, DiffractionExp and ProcessingTree

For the full list of changes, please see the CHANGELOG.rst