### PR TITLE
Release new version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 .. SPDX-License-Identifier: CC0-1.0
 
 
-v25.mm.dd
+v25.05.16
 =========
 
 Improvements

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,8 +26,8 @@ identifiers:
   - description: The pydidas project DOI
     type: doi
     value: "10.5281/zenodo.7568610"
-date-released: 2025-04-08
-version: 25.04.08
+date-released: 2025-05-16
+version: 25.05.16
 funding:
   - funder: Deutsche Forschungsgemeinschaft (DFG)
     grant: 460248799

--- a/pydidas/version.py
+++ b/pydidas/version.py
@@ -23,7 +23,7 @@ Module with the pydidas Version number.
 __author__ = "Malte Storm"
 __copyright__ = "Copyright 2024 - 2025, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
-__version__ = "25.04.08"
+__version__ = "25.05.16"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
 

--- a/src/pydidas/gui/utils/main_menu_utils.py
+++ b/src/pydidas/gui/utils/main_menu_utils.py
@@ -146,10 +146,18 @@ def get_update_check_text(
         _text = (
             "A new version of pydidas is available.\n\n"
             f"    Locally installed version: {VERSION}\n"
-            f"    Latest release: {remote_version}.\n\n"
+            f"    Latest release: {remote_version}."
         )
         if auto_check and remote_version not in ["-1", acknowledged_update]:
-            _text += "Please update pydidas to benefit from the latest improvements."
+            _text += (
+                "\n\nPlease update pydidas to benefit from the latest improvements."
+            )
+        if remote_version not in ["-1", acknowledged_update]:
+            _text += (
+                "\n\nThe most convenient way to upgrade pydidas is using pip:\n\n"
+                "python -m pip install --upgrade pydidas\n\n"
+                "(called from the command line in the\nrespective python environment)"
+            )
     else:
         _text = (
             f"The locally installed version of pydidas (version {VERSION}) \n"

--- a/src/pydidas/version.py
+++ b/src/pydidas/version.py
@@ -23,7 +23,7 @@ Module with the pydidas Version number.
 __author__ = "Malte Storm"
 __copyright__ = "Copyright 2024 - 2025, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
-__version__ = "25.04.08"
+__version__ = "25.05.16"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
 


### PR DESCRIPTION
Release of new version with improvements for residual stress analysis and a number of bugfixes. 

- Enhanced residual stress analysis plugins with new features and support for additional input geometries.
- Added options for filename filtering, and manual directory input in the DataBrowsingFrame.
- Added support for Qt6. For now, Qt5 is still the standard backend but Qt6 can be used, if required (e.g. call the GUI with a --qt6 option)

For the full list of changes and bugfixes, please refer to the CHANGELOG