### PR TITLE
Allow entering filename in DataBrowser

### DIFF
--- a/src/pydidas/gui/frames/builders/data_browsing_frame_builder.py
+++ b/src/pydidas/gui/frames/builders/data_browsing_frame_builder.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -21,7 +21,7 @@ the DataBrowsingFrame with widgets.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -92,7 +92,7 @@ DATA_BROWSING_FRAME_BUILD_CONFIG: list[list[str | tuple[Any] | dict[str, Any]]] 
         {
             "gridPos": (0, 1, 1, 2),
             "parent_widget": "plot_header",
-            "readOnly": True,
+            "readOnly": False,
             "sizePolicy": POLICY_EXP_EXP,
         },
     ],

--- a/src/pydidas/gui/frames/data_browsing_frame.py
+++ b/src/pydidas/gui/frames/data_browsing_frame.py
@@ -101,6 +101,9 @@ class DataBrowsingFrame(BaseFrame, AssociatedFileMixin):
         """
         self._widgets["explorer"].sig_new_file_selected.connect(self.__file_selected)
         self._widgets["filename"].returnPressed.connect(self.__filename_input)
+        self._widgets["filename"].editingFinished.connect(
+            self.__set_filename_input_text
+        )
         self.param_widgets["xcol"].sig_new_value.connect(self.__display_ascii_data)
         self._widgets["hdf5_dataset_selector"].sig_new_dataset_selected.connect(
             self.__display_hdf5_dataset
@@ -169,7 +172,7 @@ class DataBrowsingFrame(BaseFrame, AssociatedFileMixin):
             get_extension(filename) not in self.__supported_extensions
             or not Path(filename).is_file()
         ):
-            self._widgets["filename"].setText(self.current_filename)
+            self.__set_filename_input_text()
             self._widgets["viewer"].set_data(None)
             if self.__browser_window is not None:
                 self.__browser_window.hide()
@@ -181,7 +184,7 @@ class DataBrowsingFrame(BaseFrame, AssociatedFileMixin):
         if self.__metadata_window is not None:
             self.__metadata_window.hide()
         self._widgets["viewer"].set_data(None)
-        self._widgets["filename"].setText(self.current_filename)
+        self.__set_filename_input_text()
         self._widgets["ascii_widgets"].setVisible(self.ascii_file)
         self._widgets["hdf5_dataset_selector"].setVisible(self.hdf5_file)
         self._widgets["configure_binary_decoding"].set_new_filename(filename)
@@ -195,6 +198,15 @@ class DataBrowsingFrame(BaseFrame, AssociatedFileMixin):
 
     def __filename_input(self):
         self.__file_selected(self._widgets["filename"].text())
+
+    def __set_filename_input_text(self):
+        """
+        Update filename input text only if it does not already match the current
+        filename. This is to prevent the text cursor from jumping to the end of
+        the filename when using the filename input field.
+        """
+        if self._widgets["filename"].text() != self.current_filename:
+            self._widgets["filename"].setText(self.current_filename)
 
     def __open_hdf5_file(self) -> None:
         """Process the input file and check whether it is a hdf5 file."""

--- a/src/pydidas/gui/frames/data_browsing_frame.py
+++ b/src/pydidas/gui/frames/data_browsing_frame.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -21,7 +21,7 @@ dedicated filesystem tree and show file data in a view window.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -100,6 +100,7 @@ class DataBrowsingFrame(BaseFrame, AssociatedFileMixin):
         Connect all required signals and slots between widgets and class methods.
         """
         self._widgets["explorer"].sig_new_file_selected.connect(self.__file_selected)
+        self._widgets["filename"].returnPressed.connect(self.__filename_input)
         self.param_widgets["xcol"].sig_new_value.connect(self.__display_ascii_data)
         self._widgets["hdf5_dataset_selector"].sig_new_dataset_selected.connect(
             self.__display_hdf5_dataset
@@ -161,6 +162,10 @@ class DataBrowsingFrame(BaseFrame, AssociatedFileMixin):
         filename : str
             The full file name (including directory) of the selected file.
         """
+        if not Path(filename).is_file():
+            self._widgets["viewer"].set_data(None)
+            self.current_filename = ""
+            return
         if self.current_filename == filename:
             return
         if get_extension(filename) not in self.__supported_extensions:
@@ -182,6 +187,9 @@ class DataBrowsingFrame(BaseFrame, AssociatedFileMixin):
         elif self.generic_file:
             _data = import_data(filename)
             self.__display_dataset(_data)
+
+    def __filename_input(self):
+        self.__file_selected(self._widgets["filename"].text())
 
     def __open_hdf5_file(self) -> None:
         """Process the input file and check whether it is a hdf5 file."""

--- a/src/pydidas/gui/frames/data_browsing_frame.py
+++ b/src/pydidas/gui/frames/data_browsing_frame.py
@@ -162,19 +162,24 @@ class DataBrowsingFrame(BaseFrame, AssociatedFileMixin):
         filename : str
             The full file name (including directory) of the selected file.
         """
-        if not Path(filename).is_file():
-            self._widgets["viewer"].set_data(None)
-            self.current_filename = ""
-            return
         if self.current_filename == filename:
             return
-        if get_extension(filename) not in self.__supported_extensions:
+        self.current_filename = filename
+        if (
+            get_extension(filename) not in self.__supported_extensions
+            or not Path(filename).is_file()
+        ):
+            self._widgets["filename"].setText(self.current_filename)
+            self._widgets["viewer"].set_data(None)
+            if self.__browser_window is not None:
+                self.__browser_window.hide()
+            if self.__metadata_window is not None:
+                self.__metadata_window.hide()
             return
         if self.__browser_window is not None:
             self.__browser_window.hide()
         if self.__metadata_window is not None:
             self.__metadata_window.hide()
-        self.current_filename = filename
         self._widgets["viewer"].set_data(None)
         self._widgets["filename"].setText(self.current_filename)
         self._widgets["ascii_widgets"].setVisible(self.ascii_file)


### PR DESCRIPTION
This PR allows entering/changing the filename directly in the data browser as an alternative to using the QFileSystemModel (resolves #147)

The filename is resolved when pressing enter.
If the file exists it is loaded in the viewer just like using the QFileSystemModel.
If the file does not exist the contents of the viewer are reset

Additionally there is a small change for handling unsupported files:
Instead of doing nothing they are now handled like missing files (viewer content reset but filename updated)