### PR TITLE
Fix WorkflowTestFrame memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .idea
 .vscode
 
+# local files for AI agents
+AGENTS.md
+
 # local files from running pydidas
 .pylint.d
 .pylint.d/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # local IDE metadata files
 .idea
+.vscode
 
 # local files from running pydidas
 .pylint.d

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -76,6 +76,8 @@ Bugfixes
   data has been set to zero which caused an exception.
 - Fixed an issue in naming where some widgets had a method update_font_metrics
   with a different signature than the base method.
+- Fixed an issue in the SubtractBackgroundImage plugin which did not return
+  the correct datatype when a threshold was set.
 
 
 v26.01.27

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -78,10 +78,12 @@ Bugfixes
   with a different signature than the base method.
 - Fixed an issue in the SubtractBackgroundImage plugin which did not return
   the correct datatype when a threshold was set.
-- Fixed a memory leak in the TestWorkflowFrame.
+- Fixed a memory leak in the WorkflowTestFrame.
 - Fixed an issue which increased memory consumption when switching between plots.
 - Fixed an issue in the GenericNode which did not dereference children correctly
   in branching workflow trees.
+- Fixed an issue in the WorkflowTestFrame where the results were kept in memory
+  which used a higher peak memory.
 
 
 v26.01.27

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -78,7 +78,8 @@ Bugfixes
   with a different signature than the base method.
 - Fixed an issue in the SubtractBackgroundImage plugin which did not return
   the correct datatype when a threshold was set.
-- Fixed a memory leak in the TestWorkflowFrame
+- Fixed a memory leak in the TestWorkflowFrame.
+- Fixed an issue which increased memory consumption when switching between plots.
 
 
 v26.01.27

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -84,6 +84,8 @@ Bugfixes
   in branching workflow trees.
 - Fixed an issue in the WorkflowTestFrame where the results were kept in memory
   which used a higher peak memory.
+- Fixed an isssue where the active node was not properly updated when a node
+  was moved in a Tree.
 
 
 v26.01.27

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -80,6 +80,8 @@ Bugfixes
   the correct datatype when a threshold was set.
 - Fixed a memory leak in the TestWorkflowFrame.
 - Fixed an issue which increased memory consumption when switching between plots.
+- Fixed an issue in the GenericNode which did not dereference children correctly
+  in branching workflow trees.
 
 
 v26.01.27

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -78,6 +78,7 @@ Bugfixes
   with a different signature than the base method.
 - Fixed an issue in the SubtractBackgroundImage plugin which did not return
   the correct datatype when a threshold was set.
+- Fixed a memory leak in the TestWorkflowFrame
 
 
 v26.01.27

--- a/src/pydidas/core/dataset.py
+++ b/src/pydidas/core/dataset.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -21,7 +21,7 @@ embedded metadata.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -1253,7 +1253,7 @@ class Dataset(ndarray):
 
     def copy(self, order: Literal["C", "F", "A", "K"] = "C") -> Self:
         """
-        Overload the generic nd.ndarray copy method to copy metadata as well.
+        Create a FULL/DEEP copy of the Dataset, similar to ndarray.copy.
 
         Parameters
         ----------
@@ -1263,7 +1263,8 @@ class Dataset(ndarray):
         Returns
         -------
         Dataset
-            The copied dataset.
+            A fully independent copy with separate array data and independent
+            metadata.
         """
         _new = ndarray.copy(self, order)
         _new._meta = {
@@ -1280,6 +1281,10 @@ class Dataset(ndarray):
             except AttributeError:
                 _new._meta["metadata"][_key] = _val
         return _new
+
+    def __copy__(self) -> Self:
+        """Create a full/deep copy of the Dataset via copy.copy()."""
+        return self.copy()
 
     def __repr__(self) -> str:
         """

--- a/src/pydidas/core/dataset.py
+++ b/src/pydidas/core/dataset.py
@@ -1253,7 +1253,10 @@ class Dataset(ndarray):
 
     def copy(self, order: Literal["C", "F", "A", "K"] = "C") -> Self:
         """
-        Create a FULL/DEEP copy of the Dataset, similar to ndarray.copy.
+        Create a full copy of the Dataset, similar to ndarray.copy.
+
+        The copy method duplicates the underlying array data and metadata and
+        creates a fully independent copy.
 
         Parameters
         ----------

--- a/src/pydidas/core/dataset.py
+++ b/src/pydidas/core/dataset.py
@@ -178,7 +178,7 @@ class Dataset(ndarray):
             self._meta["_get_item_key"] = ()
         return _item
 
-    def __array_finalize__(self, obj: Self):
+    def __array_finalize__(self, obj: Self) -> None:
         """
         Finalization of numpy.ndarray object creation.
 
@@ -193,7 +193,7 @@ class Dataset(ndarray):
             obj._meta["_get_item_key"] = ()
         self._meta["_get_item_key"] = ()
 
-    def __update_keys_from_object(self, obj: ndarray):  # noqa C901
+    def __update_keys_from_object(self, obj: ndarray) -> None:  # noqa C901
         """
         Update the axis keys from the original object.
 
@@ -249,7 +249,7 @@ class Dataset(ndarray):
                 for _dim, (_key, _item) in enumerate(sorted(self._meta[_item].items()))
             }
 
-    def __insert_axis_keys(self, dim: int):
+    def __insert_axis_keys(self, dim: int) -> None:
         """
         Insert a new axis key at the specified dimension.
 
@@ -265,7 +265,7 @@ class Dataset(ndarray):
             _vals.insert(dim, _new_entry)
             self._meta[_item] = {_i: _val for _i, _val in enumerate(_vals)}
 
-    def flatten_dims(self, *args: tuple[int], **kwargs: Any):
+    def flatten_dims(self, *args: int, **kwargs: Any) -> None:
         """
         Flatten the specified dimensions **in place** in the Dataset.
 
@@ -277,9 +277,9 @@ class Dataset(ndarray):
 
         Parameters
         ----------
-        *args : tuple[int]
-            The tuple of the dimensions to be flattened. Each dimension must
-            be an integer entry.
+        *args : int
+            The dimensions to be flattened. Each dimension must be an integer
+            entry.
         **kwargs: Any
             Additional keyword arguments. Supported keywords are:
 
@@ -288,9 +288,9 @@ class Dataset(ndarray):
                 'Flattened'.
             new_dim_unit : str, optional
                 The unit for the new, flattened dimension. The default is ''.
-            new_dim_range : Union[None, ndarray, Iterable], optional
-                The new range for the flattened dimension. If None, a simple The
-                default is None.
+            new_dim_range : None or ndarray or Iterable, optional
+                The new range for the flattened dimension. If None, a default
+                range is used. The default is None.
         """
         if len(args) < 2:
             return
@@ -607,7 +607,7 @@ class Dataset(ndarray):
         _ranges = get_input_as_dict(ranges, self.shape, "axis_ranges")
         self._meta["axis_ranges"] = convert_ranges_and_check_length(_ranges, self.shape)
 
-    def __check_property_length(self, key: str):
+    def __check_property_length(self, key: str) -> None:
         """
         Check the length of the axis properties.
 
@@ -631,7 +631,7 @@ class Dataset(ndarray):
     # Update methods for the axis properties
     # ######################################
 
-    def update_axis_range(self, index: int, item: ArrayLike):
+    def update_axis_range(self, index: int, item: ArrayLike) -> None:
         """
         Update a single axis range value.
 
@@ -651,7 +651,7 @@ class Dataset(ndarray):
         _new = convert_ranges_and_check_length({index: item}, self.shape)
         self._meta["axis_ranges"][index] = _new[index]
 
-    def update_axis_label(self, index: int, item: str):
+    def update_axis_label(self, index: int, item: str) -> None:
         """
         Update a single axis label value.
 
@@ -675,7 +675,7 @@ class Dataset(ndarray):
             )
         self._meta["axis_labels"][index] = item
 
-    def update_axis_unit(self, index: int, item: str):
+    def update_axis_unit(self, index: int, item: str) -> None:
         """
         Update a single axis unit value.
 
@@ -1394,7 +1394,7 @@ class Dataset(ndarray):
         ndarray.__setstate__(self, state[0:-1])
 
     def __array_wrap__(
-        self, obj: ndarray, context: object | None = None, return_scalar=False
+        self, obj: ndarray, context: object | None = None, return_scalar: bool = False
     ) -> Self:
         """
         Return 0-d results from ufuncs as single values.

--- a/src/pydidas/core/object_with_parameter_collection.py
+++ b/src/pydidas/core/object_with_parameter_collection.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -22,7 +22,7 @@ It includes a ParameterCollection object.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -56,7 +56,7 @@ class ObjectWithParameterCollection(
     QObject is not possible.
     """
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, **kwargs: Any) -> None:
         QtCore.QObject.__init__(self, parent=kwargs.get("parent", None))
         PydidasQsettingsMixin.__init__(self)
         ParameterCollectionMixIn.__init__(self)
@@ -109,7 +109,7 @@ class ObjectWithParameterCollection(
             _state["_config"]["shared_memory"] = {}
         return _state
 
-    def __setstate__(self, state: dict):
+    def __setstate__(self, state: dict) -> None:
         """
         Set the ObjectWithParameterCollection state from a pickled state.
 
@@ -133,19 +133,36 @@ class ObjectWithParameterCollection(
         int
             The hash value.
         """
+        _param_hash = hash(self.params)
+        _config_hash = self.__hash_dict(self._config)
+        return hash((_param_hash, _config_hash))
+
+    def __hash_dict(self, item: dict) -> int:
+        """
+        Get a hash value for a dictionary.
+
+        Parameters
+        ----------
+        item : dict
+            The dictionary to hash.
+        """
+        if item == {}:
+            return 0
         _config_keys = []
         _config_vals = []
-        _param_hash = hash(self.params)
-        for _key, _val in self._config.items():
+        for _key, _val in item.items():
             _config_keys.append(hash(_key))
             try:
-                if isinstance(_val, list):
-                    _val = tuple(_val)
-                _hash = hash(_val)
+                if isinstance(_val, dict):
+                    _hash = self.__hash_dict(_val)
+                else:
+                    if isinstance(_val, list):
+                        _val = tuple(_val)
+                    _hash = hash(_val)
                 _config_vals.append(_hash)
             except TypeError:
                 warnings.warn(f'Could not hash the dictionary value "{_val}".')
-        return hash((_param_hash, tuple(_config_keys), tuple(_config_vals)))
+        return hash((tuple(_config_keys), tuple(_config_vals)))
 
     def copy(self) -> Self:
         """

--- a/src/pydidas/gui/frames/builders/view_results_frame_builder.py
+++ b/src/pydidas/gui/frames/builders/view_results_frame_builder.py
@@ -34,7 +34,7 @@ from qtpy import QtCore
 
 from pydidas.core.constants import FONT_METRIC_CONFIG_WIDTH, POLICY_FIX_EXP
 from pydidas.widgets import ScrollArea
-from pydidas.widgets.data_viewer import TableWithResultDatasets
+from pydidas.widgets.data_viewer import TableWithNodeLabels
 from pydidas.widgets.misc import ReadOnlyTextWidget
 
 
@@ -99,7 +99,7 @@ VIEW_RESULTS_MIXIN_BUILD_CONFIG: list[list[str | tuple[Any] | dict[str, Any]]] =
     ],
     [
         "create_any_widget",
-        ("result_table", TableWithResultDatasets),
+        ("result_table", TableWithNodeLabels),
         {"parent_widget": "config", "visible": False},
     ],
     [

--- a/src/pydidas/gui/frames/builders/workflow_test_frame_builder.py
+++ b/src/pydidas/gui/frames/builders/workflow_test_frame_builder.py
@@ -31,7 +31,7 @@ from qtpy import QtCore
 
 from pydidas.core.constants import FONT_METRIC_CONFIG_WIDTH, POLICY_FIX_EXP
 from pydidas.widgets import ScrollArea
-from pydidas.widgets.data_viewer import DataViewer, TableWithResultDatasets
+from pydidas.widgets.data_viewer import DataViewer, TableWithNodeLabels
 from pydidas.widgets.framework import BaseFrame
 from pydidas.widgets.misc import ReadOnlyTextWidget
 
@@ -174,7 +174,7 @@ def get_WorkflowTestFrame_build_config(
             ],
             [
                 "create_any_widget",
-                ("result_table", TableWithResultDatasets),
+                ("result_table", TableWithNodeLabels),
                 {
                     "font_metric_width_factor": FONT_METRIC_CONFIG_WIDTH,
                     "font_metric_height_factor": 10,

--- a/src/pydidas/gui/frames/view_results_frame.py
+++ b/src/pydidas/gui/frames/view_results_frame.py
@@ -42,7 +42,7 @@ from pydidas.gui.frames.builders.view_results_frame_builder import (
 from pydidas.widgets import PydidasFileDialog
 from pydidas.widgets.data_viewer import DataViewer
 from pydidas.widgets.dialogues import critical_warning
-from pydidas.widgets.framework import BaseFrame, BaseFrameWithApp
+from pydidas.widgets.framework import BaseFrameWithApp
 from pydidas.widgets.windows import ShowInformationForResult
 from pydidas.workflow import (
     ProcessingResults,
@@ -108,7 +108,7 @@ class ViewResultsFrame(BaseFrameWithApp):
             gridPos=(1, 1, 2, 1),
         )
         _layout = self.layout()
-        _layout.setRowStretch(_layout.rowCount() - 1, 1)  # noqa: E0602
+        _layout.setRowStretch(_layout.rowCount() - 1, 1)  # type: ignore[attr-defined]
         if self._config["enable_import"]:
             self.__import_dialog = PydidasFileDialog()
         self._widgets["import_container"].setVisible(self._config["enable_import"])
@@ -128,22 +128,6 @@ class ViewResultsFrame(BaseFrameWithApp):
         self._widgets["but_export_current"].clicked.connect(self._export_current)
         self._widgets["but_export_all"].clicked.connect(self._export_all)
 
-    @QtCore.Slot(int)
-    def frame_activated(self, index: int) -> None:
-        """
-        Received a signal that a new frame has been selected.
-
-        This method checks whether the selected frame is the current class
-        and if yes, it will call some updates.
-
-        Parameters
-        ----------
-        index : int
-            The index of the newly activated frame.
-        """
-        BaseFrame.frame_activated(self, index)
-        self._config["frame_active"] = index == self.frame_index
-
     def import_data_to_workflow_results(self) -> None:
         """Import data to the workflow results."""
         _dir = self.__import_dialog.get_existing_directory(
@@ -151,10 +135,10 @@ class ViewResultsFrame(BaseFrameWithApp):
             qsettings_ref="WorkflowResults__import",
         )
         if _dir is not None:
-            self._RESULTS.import_data_from_directory(_dir)  # noqa: W0212
-            _tree = self._RESULTS._TREE  # noqa: W0212
-            _tree.root.plugin._SCAN = self._RESULTS._SCAN  # noqa: W0212
-            _tree.root.plugin.update_filepath()  # noqa: W0212
+            self._RESULTS.import_data_from_directory(_dir)
+            _tree = self._RESULTS._TREE
+            _tree.root.plugin._SCAN = self._RESULTS._SCAN
+            _tree.root.plugin.update_filepath()
             self.update_choices_of_selected_results()
             self._selected_new_node(-1)
 
@@ -163,8 +147,8 @@ class ViewResultsFrame(BaseFrameWithApp):
         _should_be_visible = len(self._RESULTS.result_titles) > 0
         self._widgets["label_select_header"].setVisible(_should_be_visible)
         self._widgets["result_table"].setVisible(_should_be_visible)
-        self._widgets["result_table"].update_choices_from_workflow_results(
-            self._RESULTS
+        self._widgets["result_table"].update_node_descriptions(
+            self._RESULTS.result_titles
         )
 
     def update_export_setting_visibility(self) -> None:
@@ -270,7 +254,7 @@ class ViewResultsFrame(BaseFrameWithApp):
         if self._active_node_id == -1:
             critical_warning(
                 "No node selected",
-                ("No node has been selected. Please select a node and try again."),
+                "No node has been selected. Please select a node and try again.",
             )
             return
         self._export(self._active_node_id)

--- a/src/pydidas/gui/frames/workflow_test_frame.py
+++ b/src/pydidas/gui/frames/workflow_test_frame.py
@@ -29,7 +29,6 @@ __all__ = ["WorkflowTestFrame"]
 
 
 import copy
-import gc
 from typing import Any
 
 from qtpy import QtCore
@@ -303,6 +302,7 @@ class WorkflowTestFrame(BaseFrame):
         if not self._check_tree_is_populated():
             return
         with utils.ShowBusyMouse():
+            self.clear_results()
             _index = self.__get_index()
             self._tree.execute_process(
                 _index,
@@ -323,9 +323,10 @@ class WorkflowTestFrame(BaseFrame):
         Reload the local WorkflowTree from the global one, e.g. to propagate changes
         to global settings.
         """
+        if self._tree:
+            self._tree.clear()
         self.clear_results()
         self._tree = TREE.deepcopy()
-        gc.collect()
 
     @staticmethod
     def _check_tree_is_populated() -> bool:
@@ -478,6 +479,7 @@ class WorkflowTestFrame(BaseFrame):
 
     def clear_results(self) -> None:
         """Clear all stored results."""
+        self._widgets["plot"].set_data(None)
         self._results = {}
         self._result_titles = {}
         self.__update_selection_choices()

--- a/src/pydidas/gui/frames/workflow_test_frame.py
+++ b/src/pydidas/gui/frames/workflow_test_frame.py
@@ -439,12 +439,11 @@ class WorkflowTestFrame(BaseFrame):
         """
         Store the WorkflowTree results in a local dictionary.
         """
-        _meta = self._tree.get_complete_plugin_metadata()
-        self._result_titles = _meta["result_titles"]
+        self._result_titles = self._tree.get_plugin_metadata("result_titles")
         for _node_id, _node in self._tree.nodes.items():
             _data = _node.results
             if _data is not None:
-                if 1 in set(_data.shape) and _data.shape != (1,):
+                if 1 in _data.shape and _data.ndim > 1:
                     _data = _data.squeeze()
                 self._results[_node_id] = _data
         if self._active_node not in self._results:

--- a/src/pydidas/gui/frames/workflow_test_frame.py
+++ b/src/pydidas/gui/frames/workflow_test_frame.py
@@ -29,6 +29,7 @@ __all__ = ["WorkflowTestFrame"]
 
 
 import copy
+import gc
 from typing import Any
 
 from qtpy import QtCore
@@ -144,7 +145,7 @@ class WorkflowTestFrame(BaseFrame):
     The WorkflowTestFrame allows to run / test the workflow on a single datapoint.
 
     The selection of a frame can be done either using the absolute frame number
-    (if the ``image_selection`` Parameter equals "Use global index") or by
+    (if the ``image_selection`` Parameter equals "Use global index"), or by
     supplying scan indices for all active scan dimensions (if the
     ``image_selection`` Parameter equals "Use scan dimensional indices").
     """
@@ -322,8 +323,9 @@ class WorkflowTestFrame(BaseFrame):
         Reload the local WorkflowTree from the global one, e.g. to propagate changes
         to global settings.
         """
-        self._tree = TREE.deepcopy()
         self.clear_results()
+        self._tree = TREE.deepcopy()
+        gc.collect()
 
     @staticmethod
     def _check_tree_is_populated() -> bool:

--- a/src/pydidas/gui/frames/workflow_test_frame.py
+++ b/src/pydidas/gui/frames/workflow_test_frame.py
@@ -139,14 +139,6 @@ def _create_str_description_of_node_result(
     return _str
 
 
-class _ResultsMock:
-    """Mock class to store result titles."""
-
-    def __init__(self) -> None:
-        """Initialize the _ResultsMock."""
-        self.result_titles = {}
-
-
 class WorkflowTestFrame(BaseFrame):
     """
     The WorkflowTestFrame allows to run / test the workflow on a single datapoint.
@@ -187,7 +179,6 @@ class WorkflowTestFrame(BaseFrame):
         self._tree = None
         self._active_node = -1
         self._results = {}
-        self._local_results_mock = _ResultsMock()
         self._config.update(
             {
                 "shapes": {},
@@ -447,7 +438,7 @@ class WorkflowTestFrame(BaseFrame):
         Store the WorkflowTree results in a local dictionary.
         """
         _meta = self._tree.get_complete_plugin_metadata()
-        self._local_results_mock.result_titles = _meta["result_titles"]
+        self._result_titles = _meta["result_titles"]
         for _node_id, _node in self._tree.nodes.items():
             _data = _node.results
             if _data is not None:
@@ -459,9 +450,7 @@ class WorkflowTestFrame(BaseFrame):
 
     def __update_selection_choices(self) -> None:
         """Update the choice of results to display"""
-        self._widgets["result_table"].update_choices_from_workflow_results(
-            self._local_results_mock
-        )
+        self._widgets["result_table"].update_node_descriptions(self._result_titles)
 
     @QtCore.Slot(int)
     def _selected_new_node(self, index: int) -> None:
@@ -489,7 +478,7 @@ class WorkflowTestFrame(BaseFrame):
     def clear_results(self) -> None:
         """Clear all stored results."""
         self._results = {}
-        self._local_results_mock.result_titles = {}
+        self._result_titles = {}
         self.__update_selection_choices()
         self.__set_derived_widget_visibility(False)
 

--- a/src/pydidas/gui/frames/workflow_test_frame.py
+++ b/src/pydidas/gui/frames/workflow_test_frame.py
@@ -467,6 +467,9 @@ class WorkflowTestFrame(BaseFrame):
         self._active_node = index
         if index == -1:
             self._config["has_details"] = False
+            self._config["plot_active"] = False
+            if self._widgets["plot"].data_is_set:
+                self._widgets["plot"].set_data(None)
             return
         else:
             self._config["plot_active"] = True
@@ -479,7 +482,8 @@ class WorkflowTestFrame(BaseFrame):
 
     def clear_results(self) -> None:
         """Clear all stored results."""
-        self._widgets["plot"].set_data(None)
+        if self._widgets["plot"].data_is_set:
+            self._widgets["plot"].set_data(None)
         self._results = {}
         self._result_titles = {}
         self.__update_selection_choices()
@@ -515,12 +519,7 @@ class WorkflowTestFrame(BaseFrame):
         self._widgets["result_info"].setText(_str)
 
     def __plot_results(self) -> None:
-        """
-        Update the plot.
-
-        This method will get the latest result (subset) from the
-        ProcessingResults and update the plot.
-        """
+        """Update the plot with the latest data"""
         if self._active_node == -1 or not self._config["plot_active"]:
             return
         self._widgets["plot"].set_data(self._results[self._active_node])

--- a/src/pydidas/gui/frames/workflow_test_frame.py
+++ b/src/pydidas/gui/frames/workflow_test_frame.py
@@ -484,6 +484,8 @@ class WorkflowTestFrame(BaseFrame):
         """Clear all stored results."""
         if self._widgets["plot"].data_is_set:
             self._widgets["plot"].set_data(None)
+        if self._tree and self._tree.root:
+            self._tree.root.clear_data(recursive=True)
         self._results = {}
         self._result_titles = {}
         self.__update_selection_choices()

--- a/src/pydidas/gui/frames/workflow_test_frame.py
+++ b/src/pydidas/gui/frames/workflow_test_frame.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -21,7 +21,7 @@ workflow on a single data frame.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"

--- a/src/pydidas/widgets/data_viewer/__init__.py
+++ b/src/pydidas/widgets/data_viewer/__init__.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2025, Helmholtz-Zentrum Hereon
+# Copyright 2025 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -20,7 +20,7 @@ Package with subclassed silx widgets and actions.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2025 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -29,20 +29,15 @@ __status__ = "Production"
 from .axes_selector import AxesSelector
 from .data_axis_selector import DataAxisSelector
 from .data_viewer import DataViewer
-from .table_with_result_datasets import TableWithResultDatasets
+from .table_with_node_labels import TableWithNodeLabels
 
 
-__all__ = [
-    axes_selector.__all__
-    + data_axis_selector.__all__
-    + data_viewer.__all__
-    + table_with_result_datasets.__all__
-]
+__all__ = ["AxesSelector", "DataAxisSelector", "DataViewer", "TableWithNodeLabels"]
 
 # Clean up the namespace:
 del (
     axes_selector,
     data_axis_selector,
     data_viewer,
-    table_with_result_datasets,
+    table_with_node_labels,
 )

--- a/src/pydidas/widgets/data_viewer/data_viewer.py
+++ b/src/pydidas/widgets/data_viewer/data_viewer.py
@@ -28,6 +28,7 @@ __all__ = ["DataViewer"]
 
 
 from functools import partial
+from typing import Any
 
 import h5py
 import numpy as np
@@ -65,7 +66,7 @@ class DataViewer(WidgetWithParameterCollection):
     ]
     sig_plot2d_get_more_info_for_data = QtCore.Signal(float, float)
 
-    def __init__(self, parent: QtWidgets.QWidget | None = None, **kwargs: dict):
+    def __init__(self, parent: QtWidgets.QWidget | None = None, **kwargs: Any) -> None:
         WidgetWithParameterCollection.__init__(self, parent=parent, **kwargs)
 
         self._data = None
@@ -387,7 +388,7 @@ class DataViewer(WidgetWithParameterCollection):
             self._config["plot_title"] = title
         if not (isinstance(data, np.ndarray) and isinstance(self._data, np.ndarray)):
             raise UserConfigError(
-                "Can only update data if both the stored data and the new data"
+                "Can only update data if both the stored data and the new data "
                 "are np.ndarrays."
             )
         if data.shape != self._data.shape:

--- a/src/pydidas/widgets/data_viewer/data_viewer.py
+++ b/src/pydidas/widgets/data_viewer/data_viewer.py
@@ -32,6 +32,7 @@ from functools import partial
 import h5py
 import numpy as np
 from qtpy import QtCore, QtWidgets
+from qtpy.QtWidgets import QWidget
 from silx.gui.hdf5 import H5Node
 
 from pydidas.core import Dataset, UserConfigError
@@ -322,6 +323,10 @@ class DataViewer(WidgetWithParameterCollection):
                 "The data to display must be a numpy array, a h5py.Dataset or a "
                 "H5Node object."
             )
+        for _key in DATA_VIEW_CONFIG:
+            _widget = self._widgets.get(_key)
+            if isinstance(_widget, QWidget):
+                _widget.clear()
         self._data = data
 
     def _update_widgets_from_data(self) -> None:

--- a/src/pydidas/widgets/data_viewer/data_viewer.py
+++ b/src/pydidas/widgets/data_viewer/data_viewer.py
@@ -254,6 +254,7 @@ class DataViewer(WidgetWithParameterCollection):
             _data = self._data
         if not isinstance(_data, Dataset):
             _data = Dataset(_data)
+        _view.clear()
         _view.display_data(_data, title=self._config["plot_title"])
 
     def set_data(
@@ -268,8 +269,8 @@ class DataViewer(WidgetWithParameterCollection):
         Parameters
         ----------
         data : H5Node or h5py.Dataset or np.ndarray or None
-            The data to display. A ndarray is acceptable but will be converted to a
-            pydidas.core.Dataset object.
+            The data to display. A ndarray is acceptable but will be converted
+            to a pydidas.core.Dataset object.
         title : str or None, optional
             The title of the data. If None, the title will not be updated.
         h5node : H5Node or None, optional
@@ -281,6 +282,9 @@ class DataViewer(WidgetWithParameterCollection):
         # Remove the data reference from the h5 view:
         if "view-h5" in self._widgets:
             self._widgets["view-h5"].setData(None)
+        # Explicitly clear old data references to break circular refs
+        self._data = None
+        self._h5node = None
         if data is None:
             if self._active_view is not None:
                 self._widgets[self._active_view].clear()
@@ -288,7 +292,6 @@ class DataViewer(WidgetWithParameterCollection):
             return
         if isinstance(data, H5Node):
             h5node = data
-        # if isinstance(h5node, H5Node):
         self._h5node = h5node
         if title is not None:
             self._config["plot_title"] = title

--- a/src/pydidas/widgets/data_viewer/table_with_node_labels.py
+++ b/src/pydidas/widgets/data_viewer/table_with_node_labels.py
@@ -43,7 +43,7 @@ class TableWithNodeLabels(PydidasQTable):
 
     sig_node_selected = QtCore.Signal(int)
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, **kwargs: Any) -> None:
         kwargs["font_metric_width_factor"] = kwargs.get(
             "font_metric_width_factor", FONT_METRIC_CONFIG_WIDTH
         )
@@ -54,14 +54,14 @@ class TableWithNodeLabels(PydidasQTable):
         self.selectionModel().selectionChanged.connect(self.emit_new_node_selection)
 
     @QtCore.Slot()
-    def emit_new_node_selection(self):
+    def emit_new_node_selection(self) -> None:
         """
         Emit the signal of a new selection.
         """
         if self.selected_row_id >= 0:
             self.sig_node_selected.emit(self._row_items[self.selected_row_id])
 
-    def update_node_descriptions(self, titles: dict[int, str]):
+    def update_node_descriptions(self, titles: dict[int, str]) -> None:
         """
         Update the available choices from the WorkflowResults.
 

--- a/src/pydidas/widgets/data_viewer/table_with_node_labels.py
+++ b/src/pydidas/widgets/data_viewer/table_with_node_labels.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas
 #
-# Copyright 2025, Helmholtz-Zentrum Hereon
+# Copyright 2025 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -16,15 +16,16 @@
 # along with pydidas If not, see <http://www.gnu.org/licenses/>.
 
 """
-Module with the TableWithResultDatasets class which is a table to select result datasets.
+Module with the TableWithNodeLabels class which is a table to select result datasets.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2025 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
-__all__ = ["TableWithResultDatasets"]
+__all__ = ["TableWithNodeLabels"]
+
 
 from typing import Any
 
@@ -35,16 +36,10 @@ from pydidas.core.constants import (
 )
 from pydidas.core.utils import apply_qt_properties
 from pydidas.widgets.factory.pydidas_table import PydidasQTable
-from pydidas.workflow import ProcessingResults, WorkflowResults
 
 
-RESULTS = WorkflowResults()
-
-
-class TableWithResultDatasets(PydidasQTable):
-    """
-    A QTableWidget used for selecting a dataset from the workflow results.
-    """
+class TableWithNodeLabels(PydidasQTable):
+    """A QTableWidget used for selecting a node result from their titles."""
 
     sig_node_selected = QtCore.Signal(int)
 
@@ -66,20 +61,19 @@ class TableWithResultDatasets(PydidasQTable):
         if self.selected_row_id >= 0:
             self.sig_node_selected.emit(self._row_items[self.selected_row_id])
 
-    def update_choices_from_workflow_results(self, results: ProcessingResults):
+    def update_node_descriptions(self, titles: dict[int, str]):
         """
         Update the available choices from the WorkflowResults.
 
         Parameters
         ----------
-        results : ProcessingResults
-            The ProcessingResults instance.
+        titles: dict[int, str]
+            The dictionary with node ids and their corresponding labels.
         """
-        _labels = results.result_titles
         self.remove_all_rows()
-        self._row_items = {_i: _node_id for _i, _node_id in enumerate(_labels)}
-        self.setRowCount(len(_labels))
-        for _i_row, (_node_id, _label) in enumerate(_labels.items()):
+        self._row_items = {_i: _node_id for _i, _node_id in enumerate(titles)}
+        self.setRowCount(len(titles))
+        for _i_row, (_node_id, _label) in enumerate(titles.items()):
             self.setItem(_i_row, 0, QtWidgets.QTableWidgetItem(_label))
         self.setVisible(True)
         self.setFixedHeight(self.table_display_height)

--- a/src/pydidas/widgets/factory/pydidas_table.py
+++ b/src/pydidas/widgets/factory/pydidas_table.py
@@ -57,9 +57,7 @@ class PydidasQTable(PydidasWidgetMixin, QtWidgets.QTableWidget):
     sig_row_selected = QtCore.Signal(int)
 
     def __init__(self, **kwargs: Any) -> None:
-        kwargs["font_metric_height_factor"] = kwargs.get(
-            "font_metric_height_factor", 6
-        )
+        kwargs["font_metric_height_factor"] = kwargs.get("font_metric_height_factor", 6)
         self._rel_column_widths = kwargs.pop("relative_column_widths", None)
         self._autoscale_height = kwargs.pop("autoscale_height", False)
         self._qtapp = PydidasQApplication.instance()
@@ -117,9 +115,7 @@ class PydidasQTable(PydidasWidgetMixin, QtWidgets.QTableWidget):
         self.sig_row_selected.emit(self.selected_row_id)
 
     @QtCore.Slot(float, float)
-    def process_new_font_metrics(
-        self, char_width: float, char_height: float
-    ) -> None:
+    def process_new_font_metrics(self, char_width: float, char_height: float) -> None:
         """
         Adjust the widget's width based on the font metrics.
 

--- a/src/pydidas/widgets/factory/pydidas_table.py
+++ b/src/pydidas/widgets/factory/pydidas_table.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas
 #
-# Copyright 2025, Helmholtz-Zentrum Hereon
+# Copyright 2025 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -20,7 +20,7 @@ Module with the PydidasQTable class which is a table which scales in size with t
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2025 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"

--- a/src/pydidas/widgets/factory/pydidas_table.py
+++ b/src/pydidas/widgets/factory/pydidas_table.py
@@ -13,7 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with pydidas If not, see <http://www.gnu.org/licenses/>.
+# along with pydidas. If not, see <http://www.gnu.org/licenses/>.
 
 """
 Module with the PydidasQTable class which is a table which scales in size with the font.
@@ -56,8 +56,10 @@ class PydidasQTable(PydidasWidgetMixin, QtWidgets.QTableWidget):
 
     sig_row_selected = QtCore.Signal(int)
 
-    def __init__(self, **kwargs: Any):
-        kwargs["font_metric_height_factor"] = kwargs.get("font_metric_height_factor", 6)
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs["font_metric_height_factor"] = kwargs.get(
+            "font_metric_height_factor", 6
+        )
         self._rel_column_widths = kwargs.pop("relative_column_widths", None)
         self._autoscale_height = kwargs.pop("autoscale_height", False)
         self._qtapp = PydidasQApplication.instance()
@@ -108,14 +110,16 @@ class PydidasQTable(PydidasWidgetMixin, QtWidgets.QTableWidget):
         return _rows[0]
 
     @QtCore.Slot()
-    def emit_row_selection(self):
+    def emit_row_selection(self) -> None:
         """
         Emit the signal of a new row selection.
         """
         self.sig_row_selected.emit(self.selected_row_id)
 
     @QtCore.Slot(float, float)
-    def process_new_font_metrics(self, char_width: float, char_height: float):
+    def process_new_font_metrics(
+        self, char_width: float, char_height: float
+    ) -> None:
         """
         Adjust the widget's width based on the font metrics.
 
@@ -142,7 +146,7 @@ class PydidasQTable(PydidasWidgetMixin, QtWidgets.QTableWidget):
                         _width_i -= self._qtapp.scrollbar_width
                     self.setColumnWidth(_i_col, _width_i)
 
-    def _set_new_height(self):
+    def _set_new_height(self) -> None:
         """Set the new height of the table based on the number of rows."""
         if self._autoscale_height:
             self.resizeRowsToContents()
@@ -153,7 +157,7 @@ class PydidasQTable(PydidasWidgetMixin, QtWidgets.QTableWidget):
             _height = self.table_display_height
         self.setFixedHeight(_height)
 
-    def _handle_wrapped_cell_heights(self):
+    def _handle_wrapped_cell_heights(self) -> None:
         """
         Handle the heights of wrapped cells in the table.
 
@@ -229,8 +233,9 @@ class PydidasQTable(PydidasWidgetMixin, QtWidgets.QTableWidget):
             The label of the spanned row.
         start_col : int, optional
             The column index at which the spanned cell starts, by default 0.
-        n_col : int, optional
-            The number of columns to span, by default None which spans all columns.
+        n_col : int or None, optional
+            The number of columns to span, by default None which spans all
+            columns.
         """
         self._wrapped_cells = True
         self.setVisible(True)

--- a/src/pydidas/widgets/silx_plot/pydidas_plot1d.py
+++ b/src/pydidas/widgets/silx_plot/pydidas_plot1d.py
@@ -250,6 +250,11 @@ class PydidasPlot1D(Plot1D):
         if clear_data:
             self._current_raw_data = {}
 
+    def clear(self) -> None:
+        """Override clear to also clear the stored data."""
+        super().clear()
+        self.clear_plot()
+
     @QtCore.Slot()
     def update_mpl_fonts(self) -> None:
         """Update the plot's fonts."""

--- a/src/pydidas/widgets/silx_plot/pydidas_plot2d.py
+++ b/src/pydidas/widgets/silx_plot/pydidas_plot2d.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -21,7 +21,7 @@ additional actions.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -465,10 +465,13 @@ class PydidasPlot2D(Plot2D, PydidasQsettingsMixin):
     # uniform interface call to display data in DataViewer-like classes
     display_data = plot_pydidas_dataset
 
+    def clear(self) -> None:
+        """Override clear to also clear the stored data."""
+        super().clear()
+        self.clear_plot()
+
     def clear_plot(self) -> None:
-        """
-        Clear the plot and remove all items.
-        """
+        """Clear the plot and remove all items."""
         self.remove()
         self.setGraphTitle("")
         self.setGraphYLabel("")

--- a/src/pydidas/workflow/generic_node.py
+++ b/src/pydidas/workflow/generic_node.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -21,7 +21,7 @@ structure.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -236,6 +236,17 @@ class GenericNode:
             The list of children IDs.
         """
         return [_child.node_id for _child in self._children]
+
+    @property
+    def recursive_child_ids(self) -> list[int]:
+        """
+        Get a recursive list of the children's IDs.
+        """
+        _ids = self.children_ids
+        print("node ID / children", self.node_id, self.children_ids)
+        for _child in self.children:
+            _ids += _child.recursive_child_ids
+        return _ids
 
     def get_children(self) -> list:
         """

--- a/src/pydidas/workflow/generic_node.py
+++ b/src/pydidas/workflow/generic_node.py
@@ -43,7 +43,7 @@ class GenericNode:
     kwargs_for_copy_creation = []
 
     @staticmethod
-    def _verify_type(item: object, allowNone: bool = False):
+    def _verify_type(item: Any, allowNone: bool = False) -> None:
         """
         Check that an item is of the type class and raise a TypeError if not.
 
@@ -66,7 +66,7 @@ class GenericNode:
                 "Cannot add objects which are not of type GenericNode (or subclasses)."
             )
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, **kwargs: Any) -> None:
         """
         Set up the generic node.
 
@@ -84,7 +84,7 @@ class GenericNode:
             setattr(self, _key, _value)
         self._children = []
 
-    def add_child(self, child: Self):
+    def add_child(self, child: Self) -> None:
         """
         Add a child to the node.
 
@@ -193,7 +193,7 @@ class GenericNode:
         return self._parent
 
     @parent.setter
-    def parent(self, parent: Self | None):
+    def parent(self, parent: Self | None) -> None:
         """
         Set the node's parent.
 
@@ -243,7 +243,6 @@ class GenericNode:
         Get a recursive list of the children's IDs.
         """
         _ids = self.children_ids
-        print("node ID / children", self.node_id, self.children_ids)
         for _child in self.children:
             _ids += _child.recursive_child_ids
         return _ids
@@ -299,7 +298,13 @@ class GenericNode:
             res += child.get_recursive_ids()
         return res
 
-    def delete_node_references(self, recursive: bool = True):
+    def reset_all_node_ids(self) -> None:
+        """Reset the node_id of the node and all children in its branch to None."""
+        self.node_id = None
+        for child in self._children:
+            child.reset_all_node_ids()
+
+    def delete_node_references(self, recursive: bool = True) -> None:
         """
         Delete all references to the node from its parent and children.
 
@@ -329,7 +334,7 @@ class GenericNode:
         while self.children:
             self.children[0].delete_node_references(recursive)
 
-    def connect_parent_to_children(self):
+    def connect_parent_to_children(self) -> None:
         """
         Connect the node's parent to the node's children.
 
@@ -353,7 +358,7 @@ class GenericNode:
         self._children = []
         self.parent = None
 
-    def remove_child_reference(self, child: Self):
+    def remove_child_reference(self, child: Self) -> None:
         """
         Remove reference to an object from the node.
 
@@ -377,13 +382,13 @@ class GenericNode:
             raise ValueError("Instance is not a child!")
         self._children.remove(child)
 
-    def change_node_parent(self, new_parent: Self):
+    def change_node_parent(self, new_parent: Self) -> None:
         """
         Change the parent of the selected node.
 
         Parameters
         ----------
-        new_parent : Union[pydidas.workflow.GenericNode, None]
+        new_parent : GenericNode
             The new parent of the node.
         """
         if new_parent in [self._parent, self]:

--- a/src/pydidas/workflow/generic_node.py
+++ b/src/pydidas/workflow/generic_node.py
@@ -247,18 +247,28 @@ class GenericNode:
             _ids += _child.recursive_child_ids
         return _ids
 
-    def get_children(self) -> list:
+    def get_children(self, recursive: bool = False) -> list:
         """
         Get the child objects.
 
-        This method will return the child objects themselves.
+        This method will return the child objects themselves. The recursive
+        keyword allows to get all the children recursively.
+
+        Parameters
+        ----------
+        recursive : bool, optional
+            Keyword to toggle recursive get of the children. The default is False.
 
         Returns
         -------
         list
             A list with the children.
         """
-        return self._children
+        _children = self._children[:]
+        if recursive:
+            for _child in self.children:
+                _children += _child.get_children(recursive=True)
+        return _children
 
     def get_recursive_connections(self) -> list[list[int, int]]:
         """

--- a/src/pydidas/workflow/generic_node.py
+++ b/src/pydidas/workflow/generic_node.py
@@ -326,8 +326,8 @@ class GenericNode:
                 "Node children detected but deletion is not recursive."
             )
         self.parent = None
-        for _child in self._children:
-            _child.delete_node_references(recursive)
+        while self.children:
+            self.children[0].delete_node_references(recursive)
 
     def connect_parent_to_children(self):
         """

--- a/src/pydidas/workflow/generic_tree.py
+++ b/src/pydidas/workflow/generic_tree.py
@@ -31,7 +31,7 @@ __all__ = ["GenericTree"]
 import copy
 import time
 import warnings
-from typing import Iterable, Self, Type
+from typing import Any, Iterable, Self
 
 from qtpy import QtCore
 
@@ -45,8 +45,8 @@ class GenericTree:
     A generic tree used for organizing items.
     """
 
-    def __init__(self, **kwargs: dict):
-        self.root = None
+    def __init__(self, **kwargs: Any) -> None:
+        self._root = None
         self.node_ids = []
         self.nodes = {}
         self._config = {"tree_changed": False, "active_node_id": None} | kwargs
@@ -81,19 +81,19 @@ class GenericTree:
         return self.nodes[self.active_node_id]
 
     @property
-    def active_node_id(self) -> int:
+    def active_node_id(self) -> int | None:
         """
         Get the active node ID.
 
         Returns
         -------
-        Union[int, None]
+        int or None
             The id of the active node.
         """
         return self._config["active_node_id"]
 
     @active_node_id.setter
-    def active_node_id(self, new_id: int | None):
+    def active_node_id(self, new_id: int | None) -> None:
         """
         Set the active node ID.
 
@@ -115,11 +115,20 @@ class GenericTree:
             f"The given node ID '{new_id}' is not included in the stored node ids."
         )
 
-    def reset_tree_changed_flag(self):
-        """Reset the "has changed" flag for this Tree."""
-        self._config["tree_changed"] = False
+    @property
+    def root(self) -> GenericNode | None:
+        """
+        Retrieve the root node.
 
-    def set_root(self, node: GenericNode):
+        Returns
+        -------
+        GenericNode or None
+            The tree root node, or None if the tree is empty.
+        """
+        return self._root
+
+    @root.setter
+    def root(self, node: GenericNode | None) -> None:
         """
         Set the tree root node.
 
@@ -128,17 +137,38 @@ class GenericTree:
 
         Parameters
         ----------
-        node : GenericNode
-            The node to become the new root node
+        node : GenericNode or None
+            The node to become the new root node, or None to clear the tree.
         """
+        if node is None:
+            self.clear()
+            return
         self.verify_node_type(node)
-        self.clear()
         node.parent = None
         node.node_id = 0
+        self.clear()
         self.register_node(node)
 
+    def set_root(self, node: GenericNode | None) -> None:
+        """
+        Set the tree root node.
+
+        Note that this method will remove any references to the old parent in
+        the node!
+
+        Parameters
+        ----------
+        node : GenericNode or None
+            The node to become the new root node.
+        """
+        self.root = node
+
+    def reset_tree_changed_flag(self) -> None:
+        """Reset the "has changed" flag for this Tree."""
+        self._config["tree_changed"] = False
+
     @staticmethod
-    def verify_node_type(node):
+    def verify_node_type(node) -> None:
         """
         Check that the node is a GenericNode.
 
@@ -157,7 +187,7 @@ class GenericTree:
                 "Can only register GenericNodes (or subclasses) in the tree."
             )
 
-    def clear(self):
+    def clear(self) -> None:
         """Clear all items from the tree."""
         if self.root:
             self.delete_node_by_id(self.root.node_id)
@@ -166,14 +196,14 @@ class GenericTree:
         self._config["active_node_id"] = None
         self._config["tree_changed"] = True
         self._start_hash = hash((get_random_string(12), time.time()))
-        self.root = None
+        self._root = None
 
     def register_node(
         self,
         node: GenericNode,
         node_id: int | None = None,
         check_ids: bool = True,
-    ):
+    ) -> None:
         """
         Register a node with the tree.
 
@@ -190,21 +220,22 @@ class GenericTree:
         ----------
         node : GenericNode
             The node object to be registered.
-        node_id : int | None, optional
+        node_id : int or None, optional
             A supplied node_id. If None, the tree will select the next
             suitable node_id automatically. The default is None.
         check_ids : bool, optional
-            Keyword to enable/disable node_id checking. By default, this should always
-            be on if called by the user. If node trees are added to the GenericTree,
-            the check will only be performed once for the newly added node and not
-            again during registering of its children. The default is True.
+            Keyword to enable/disable node_id checking. By default, this should
+            always be on if called by the user. If node trees are added to the
+            GenericTree, the check will only be performed once for the newly
+            added node and not again during registering of its children. The
+            default is True.
         """
         self.verify_node_type(node)
         _ids = node.get_recursive_ids()
         if check_ids:
             self._check_node_ids(_ids)
         if self.root is None:
-            self.root = node
+            self._root = node
         if node_id is None and node.node_id is None:
             node.node_id = self.get_new_node_id()
         elif node_id is not None:
@@ -216,7 +247,7 @@ class GenericTree:
             self.register_node(_child, _child.node_id, check_ids=False)
         self._config["tree_changed"] = True
 
-    def _check_node_ids(self, node_ids: Iterable[int]):
+    def _check_node_ids(self, node_ids: Iterable[int]) -> None:
         """
         Check the compatibility of a node's (and its children) ID with the tree.
 
@@ -280,7 +311,7 @@ class GenericTree:
 
     def delete_node_by_id(
         self, node_id: int, recursive: bool = True, keep_children: bool = False
-    ):
+    ) -> None:
         """
         Remove a node from the tree and delete its object.
 
@@ -315,9 +346,12 @@ class GenericTree:
             )
         if self.nodes[node_id] == self.root:
             if self.root.n_children == 0 or recursive:
-                self.root = None
+                self._root = None
             elif self.root.n_children == 1 and keep_children:
-                self.root = self.root.get_children()[0]
+                # need to unlink the new root to prevent recursive deletion:
+                _new_root = self.root.children[0]
+                _new_root.parent = None
+                self._root = _new_root
             else:
                 raise UserConfigError(
                     "Cannot delete the root node of the tree because it has multiple "
@@ -343,7 +377,7 @@ class GenericTree:
                 self.node_ids.remove(_id)
         self._config["tree_changed"] = True
 
-    def change_node_parent(self, node_id: int, new_parent_id: int):
+    def change_node_parent(self, node_id: int, new_parent_id: int) -> None:
         """
         Change the parent of the selected node.
 
@@ -365,25 +399,29 @@ class GenericTree:
         self._config["tree_changed"] = True
 
     def order_node_ids(self) -> None:
-        """Order All the node ids of the tree's nodes."""
-        _root = self.root
-        _active_node = self.active_node
-        if _root is None:
+        """Order all the node ids of the tree's nodes."""
+        if self.root is None:
             return
-        for _node in self.nodes.values():
-            _node.node_id = None
-        self.clear()
-        self.set_root(_root)
+        _active_node = self.active_node
+        self.root.reset_all_node_ids()
+        self.node_ids = []
+        _new_nodes = {}
+        _nodes = [self.root] + self.root.get_children(recursive=True)
+        for _id, _node in enumerate(_nodes):
+            _node.node_id = _id
+            _new_nodes[_id] = _node
+            self.node_ids.append(_id)
+        self.nodes = _new_nodes
         if _active_node is not None:
             self.active_node_id = _active_node.node_id
 
-    def get_all_leaves(self) -> list[int]:
+    def get_all_leaves(self) -> list[GenericNode]:
         """
         Get all tree nodes that are leaves.
 
         Returns
         -------
-        list[int]
+        list[GenericNode]
             A list of all leaf nodes.
         """
         _leaves = []
@@ -392,21 +430,25 @@ class GenericTree:
                 _leaves.append(_node)
         return _leaves
 
-    def copy(self, as_type: Type | None = None) -> Self:
+    def copy(self, as_type=None) -> Self:
         """Wrapper for __copy__"""
         return self.__copy__(as_type=as_type)
 
     deepcopy = copy
 
-    def __copy__(self, as_type: Type | None = None) -> Self:
+    def __copy__(self, as_type: Self | None = None) -> Self:
         """
         Get a copy of the current tree.
 
+        The `as_type` argument is necessary to allow creating copies of
+        context objects which are only instances of the base object, not
+        the context.
+
         Parameters
         ----------
-        as_type : Type | None
-            The type of the object to be created. If None, the type of the
-            current instance will be used. The default is None.
+        as_type : Self | None
+            The type to which the copy should be cast. If None, the copy will be
+            of the same type as the original object. The default is None.
 
         Returns
         -------
@@ -415,14 +457,14 @@ class GenericTree:
         """
         if as_type is None:
             as_type = self.__class__
-        _copy = type(as_type.__name__, (as_type,), {})()
+        _copy = as_type()
         _copy.__dict__.update(
             {
                 _key: copy.deepcopy(_value)
                 for _key, _value in self.__dict__.items()
                 if not (
                     isinstance(_value, (QtCore.SignalInstance, QtCore.QMetaObject))
-                    or _key in ["nodes", "root"]
+                    or _key in ["nodes", "_root"]
                 )
             }
         )
@@ -433,7 +475,7 @@ class GenericTree:
             _copy.set_root(copy.deepcopy(self.root))
         return _copy
 
-    def __deepcopy__(self, memo: dict) -> Self:
+    def __deepcopy__(self, memo: dict | None = None) -> Self:
         """Wrapper for __copy__"""
         return self.__copy__()
 

--- a/src/pydidas/workflow/generic_tree.py
+++ b/src/pydidas/workflow/generic_tree.py
@@ -388,14 +388,19 @@ class GenericTree:
         new_parent_id : int
             The id of the selected node's new parent.
         """
-        _new_parent = self.nodes[new_parent_id]
-        self.nodes[node_id].change_node_parent(_new_parent)
+        _new_parent_node = self.nodes[new_parent_id]
+        self.nodes[node_id].change_node_parent(_new_parent_node)
         if new_parent_id > node_id:
-            _active_node = self.nodes[node_id]
-            _active_node.node_id = new_parent_id
-            _new_parent.node_id = node_id
-            self.nodes[new_parent_id] = _active_node
-            self.nodes[node_id] = _new_parent
+            _active_node = self.active_node
+            _child_node = self.nodes[node_id]
+            _child_node.node_id = new_parent_id
+            _new_parent_node.node_id = node_id
+            self.nodes[new_parent_id] = _child_node
+            self.nodes[node_id] = _new_parent_node
+            if _active_node == _child_node:
+                self.active_node_id = _child_node.node_id
+            if _active_node == _new_parent_node:
+                self.active_node_id = _new_parent_node.node_id
         self._config["tree_changed"] = True
 
     def order_node_ids(self) -> None:

--- a/src/pydidas/workflow/generic_tree.py
+++ b/src/pydidas/workflow/generic_tree.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -21,7 +21,7 @@ tree-like structure.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -159,6 +159,8 @@ class GenericTree:
 
     def clear(self):
         """Clear all items from the tree."""
+        if self.root:
+            self.delete_node_by_id(self.root.node_id)
         self.nodes = {}
         self.node_ids = []
         self._config["active_node_id"] = None

--- a/src/pydidas/workflow/processing_tree.py
+++ b/src/pydidas/workflow/processing_tree.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -21,7 +21,7 @@ with additional support for plugins and a plugin chain.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -31,7 +31,7 @@ __all__ = ["ProcessingTree"]
 import ast
 from numbers import Integral
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 from pydidas.core import UserConfigError
 from pydidas.core.constants import OUTPUT_PLUGIN
@@ -457,25 +457,38 @@ class ProcessingTree(GenericTree):
         ]
         return _nodes_w_results
 
-    def get_complete_plugin_metadata(self) -> dict:
+    def get_plugin_metadata(
+        self,
+        *identifiers: Literal[
+            "all", "shapes", "labels", "names", "data_labels", "result_titles"
+        ],
+    ) -> dict:
         """
         Get the metadata (e.g. shapes, labels, names) for all the tree's plugins.
 
         Note that the shapes are only available after running the plugin chain at
         least once. Otherwise, the shapes will be set to None.
 
+        Parameters
+        ----------
+        *identifiers : Literal["all", "shapes", "labels", "names",
+        "data_labels", "result_titles"]
+
+            The identifiers for the metadata to be returned. If "all" is given, all
+            metadata will be returned. Otherwise, only the specified metadata will
+            be returned.
+
         Returns
         -------
-        dict
-            The dictionary with the metadata.
+        dict[int, Any] or dict[str, dict[int, Any]]
+            The dictionary with the metadata. If only a single metadata is requested,
+            the dictionary with node IDs and metadata is returned, otherwise
+            a dictionary with the metadata keys and the respective dictionaries
+            with node IDs and metadata is returned.
         """
-        _meta = {
-            "shapes": {},
-            "labels": {},
-            "names": {},
-            "data_labels": {},
-            "result_titles": {},
-        }
+        if "all" in identifiers:
+            identifiers = ("shapes", "labels", "names", "data_labels", "result_titles")
+        _meta = {_key: {} for _key in identifiers}
         if self.root is None:
             return _meta
         _shapes = [_node.result_shape for _node in self.nodes.values()]
@@ -484,11 +497,18 @@ class ProcessingTree(GenericTree):
         for _node_id, _node in self.nodes.items():
             if _node.plugin.output_data_dim is None or _node.result_shape is None:
                 continue
-            _label = _node.plugin.get_param_value("label")
-            _plugin_name = _node.plugin.__class__.plugin_name
-            _meta["shapes"][_node_id] = _node.result_shape
-            _meta["labels"][_node_id] = _label
-            _meta["names"][_node_id] = _plugin_name
-            _meta["data_labels"][_node_id] = _node.plugin.result_data_label
-            _meta["result_titles"][_node_id] = _node.plugin.result_title
+            if "labels" in identifiers:
+                _label = _node.plugin.get_param_value("label")
+                _meta["labels"][_node_id] = _label
+            if "names" in identifiers:
+                _plugin_name = _node.plugin.__class__.plugin_name
+                _meta["names"][_node_id] = _plugin_name
+            if "shapes" in identifiers:
+                _meta["shapes"][_node_id] = _node.result_shape
+            if "data_labels" in identifiers:
+                _meta["data_labels"][_node_id] = _node.plugin.result_data_label
+            if "result_titles" in identifiers:
+                _meta["result_titles"][_node_id] = _node.plugin.result_title
+        if len(identifiers) == 1:
+            _meta = _meta[identifiers[0]]
         return _meta

--- a/src/pydidas/workflow/processing_tree.py
+++ b/src/pydidas/workflow/processing_tree.py
@@ -52,7 +52,7 @@ class ProcessingTree(GenericTree):
     class instances but through the WorkflowTree singleton instance.
     """
 
-    def __init__(self, **kwargs: dict):
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._pre_executed = False
         PLUGINS.sig_updated_plugins.connect(self.clear)
@@ -116,7 +116,7 @@ class ProcessingTree(GenericTree):
         self.register_node(_node, node_id)
         return self.node_ids[-1]
 
-    def set_root(self, node: WorkflowNode):
+    def set_root(self, node: WorkflowNode) -> None:
         """
         Set the tree root node.
 
@@ -131,7 +131,7 @@ class ProcessingTree(GenericTree):
         GenericTree.set_root(self, node)
         self.root.plugin.node_id = 0
 
-    def replace_node_plugin(self, node_id: int, new_plugin: BasePlugin):
+    def replace_node_plugin(self, node_id: int, new_plugin: BasePlugin) -> None:
         """
         Replace the plugin of the selected node with the new Plugin.
 
@@ -146,16 +146,14 @@ class ProcessingTree(GenericTree):
         self.nodes[node_id].plugin = new_plugin
         self._config["tree_changed"] = True
 
-    def get_consistent_and_inconsistent_nodes(self) -> (list, list):
+    def get_consistent_and_inconsistent_nodes(self) -> tuple[list, list]:
         """
         Get the consistency flags for all plugins in the WorkflowTree.
 
         Returns
         -------
-        list
-            The IDs of consistent nodes
-        list
-            The IDs of nodes with inconsistent data.
+        tuple[list, list]
+            A tuple with (consistent_node_ids, inconsistent_node_ids)
         """
         _consistent = []
         _inconsistent = []
@@ -186,7 +184,7 @@ class ProcessingTree(GenericTree):
         self.execute_process(arg, **kwargs)
         return self.get_current_results()
 
-    def execute_process(self, arg: object, **kwargs: dict):
+    def execute_process(self, arg: object, **kwargs: Any) -> None:
         """
         Execute the process defined in the WorkflowTree for data analysis.
 
@@ -194,13 +192,13 @@ class ProcessingTree(GenericTree):
         ----------
         arg : object
             Any argument that need to be passed to the plugin chain.
-        **kwargs : dict
+        **kwargs : Any
             Any keyword arguments which need to be passed to the plugin chain.
         """
         self.prepare_execution(**kwargs)
         self.root.execute_plugin_chain(arg, global_index=arg, **kwargs)
 
-    def prepare_execution(self, **kwargs: dict):
+    def prepare_execution(self, **kwargs: Any) -> None:
         """
         Prepare the execution of the ProcessingTree.
 
@@ -210,7 +208,7 @@ class ProcessingTree(GenericTree):
 
         Parameters
         ----------
-        **kwargs : dict, optional
+        **kwargs : Any
             Optional keyword arguments. Supported keywords are:
 
             forced : bool, optional
@@ -231,8 +229,8 @@ class ProcessingTree(GenericTree):
         self.reset_tree_changed_flag()
 
     def execute_single_plugin(
-        self, node_id: int, arg: object, **kwargs: dict
-    ) -> (object, dict):
+        self, node_id: int, arg: object, **kwargs: Any
+    ) -> tuple[object, dict]:
         """
         Execute a single node Plugin and get the return.
 
@@ -242,7 +240,7 @@ class ProcessingTree(GenericTree):
             The ID of the node in the tree.
         arg : object
             The input argument for the Plugin.
-        **kwargs : dict
+        **kwargs : Any
             Any keyword arguments for the Plugin execution.
 
         Raises
@@ -264,13 +262,13 @@ class ProcessingTree(GenericTree):
         _res, _kwargs = self.nodes[node_id].execute_plugin(arg, **kwargs)
         return _res, kwargs
 
-    def import_from_file(self, filename: Path | str):
+    def import_from_file(self, filename: Path | str) -> None:
         """
         Import the ProcessingTree from a configuration file.
 
         Parameters
         ----------
-        filename : Path | str
+        filename : Path or str
             The filename which holds the ProcessingTree configuration.
         """
         _new_tree = ProcessingTreeIoMeta.import_from_file(filename)
@@ -278,13 +276,13 @@ class ProcessingTree(GenericTree):
             setattr(self, _att, getattr(_new_tree, _att))
         self._config["tree_changed"] = True
 
-    def export_to_file(self, filename: Path | str, **kwargs: Any):
+    def export_to_file(self, filename: Path | str, **kwargs: Any) -> None:
         """
         Export the WorkflowTree to a file using any of the registered exporters.
 
         Parameters
         ----------
-        filename : Path | str
+        filename : Path or str
             The filename of the file with the export.
         """
         ProcessingTreeIoMeta.export_to_file(filename, self, **kwargs)
@@ -311,7 +309,7 @@ class ProcessingTree(GenericTree):
         """
         return [node.dump() for node in self.nodes.values()]
 
-    def restore_from_string(self, string: str):
+    def restore_from_string(self, string: str) -> None:
         """
         Restore the ProcessingTree from a string representation.
 
@@ -334,7 +332,7 @@ class ProcessingTree(GenericTree):
         self.restore_from_list_of_nodes(_nodes)
         self._config["tree_changed"] = True
 
-    def update_from_tree(self, tree: Self):
+    def update_from_tree(self, tree: Self) -> None:
         """
         Update this tree from another ProcessingTree instance.
 
@@ -348,14 +346,14 @@ class ProcessingTree(GenericTree):
         """
         self.restore_from_string(tree.export_to_string())
 
-    def restore_from_list_of_nodes(self, list_of_nodes: list | tuple):
+    def restore_from_list_of_nodes(self, list_of_nodes: list | tuple) -> None:
         """
         Restore the ProcessingTree from a list of Nodes with the required
         information.
 
         Parameters
         ----------
-        list_of_nodes : list | tuple
+        list_of_nodes : list or tuple
             A list of nodes with a dictionary entry for each node holding all
             the required information (plugin_class, node_id and plugin
             Parameters).

--- a/src/pydidas/workflow/workflow_node.py
+++ b/src/pydidas/workflow/workflow_node.py
@@ -48,7 +48,7 @@ class WorkflowNode(GenericNode):
 
     kwargs_for_copy_creation = ["plugin", "node_id"]
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, **kwargs: Any) -> None:
         self.__preprocess_kwargs(kwargs)
         super().__init__(**kwargs)
         self.results = None
@@ -90,7 +90,7 @@ class WorkflowNode(GenericNode):
         return self._plugin
 
     @plugin.setter
-    def plugin(self, new_plugin: BasePlugin):
+    def plugin(self, new_plugin: BasePlugin) -> None:
         """
         Set the plugin of the node.
         """
@@ -118,13 +118,13 @@ class WorkflowNode(GenericNode):
         return self._node_id
 
     @node_id.setter
-    def node_id(self, new_id: int | None):
+    def node_id(self, new_id: int | None) -> None:
         """
         Set the node_id.
 
         Parameters
         ----------
-        new_id : int | None
+        new_id : int or None
             The new node ID.
 
         Raises

--- a/src/pydidas/workflow/workflow_node.py
+++ b/src/pydidas/workflow/workflow_node.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -21,7 +21,7 @@ with additional support for plugins and a plugin chain.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -33,13 +33,9 @@ from numbers import Integral, Real
 from typing import Any, Self
 
 from pydidas.core import Dataset
-from pydidas.core.utils import LOGGING_LEVEL, TimerSaveRuntime, pydidas_logger
+from pydidas.core.utils import TimerSaveRuntime
 from pydidas.plugins import BasePlugin
 from pydidas.workflow.generic_node import GenericNode
-
-
-logger = pydidas_logger()
-logger.setLevel(LOGGING_LEVEL)
 
 
 class WorkflowNode(GenericNode):
@@ -61,7 +57,7 @@ class WorkflowNode(GenericNode):
         self.result_kws = None
         self.runtime = -1
 
-    def __preprocess_kwargs(self, kwargs: dict):
+    def __preprocess_kwargs(self, kwargs: dict) -> None:
         """
         Store and remove the node_id key from the calling kwargs.
 
@@ -76,7 +72,7 @@ class WorkflowNode(GenericNode):
         self.plugin = None
         self.__tmp_node_id = kwargs.pop("node_id", None)
 
-    def __confirm_plugin_existence_and_type(self):
+    def __confirm_plugin_existence_and_type(self) -> None:
         """
         Verify that a plugin exists and is of the correct type.
 
@@ -97,7 +93,7 @@ class WorkflowNode(GenericNode):
         self.plugin.node_id = self.__tmp_node_id
 
     @property
-    def node_id(self) -> Integral | None:
+    def node_id(self) -> int | None:
         """
         Get the node_id.
 
@@ -106,19 +102,19 @@ class WorkflowNode(GenericNode):
 
         Returns
         -------
-        node_id : Integral | None
+        node_id : int | None
             The node_id.
         """
         return self._node_id
 
     @node_id.setter
-    def node_id(self, new_id: Integral | None):
+    def node_id(self, new_id: int | None):
         """
         Set the node_id.
 
         Parameters
         ----------
-        new_id : Integral | None
+        new_id : int | None
             The new node ID.
 
         Raises
@@ -151,22 +147,23 @@ class WorkflowNode(GenericNode):
             _parent_out == _plugin_in or _parent_out == -1 or _plugin_in == -1
         )
 
-    def prepare_execution(self, **kwargs: dict):
+    def prepare_execution(self, **kwargs: Any) -> None:
         """
         Prepare the execution of the plugin chain.
 
-        This method recursively calls the pre_execute methods of all (child) plugins.
+        This method recursively calls the pre_execute methods of all (child)
+        plugins.
 
         Parameters
         ----------
-        **kwargs : dict
+        **kwargs : Any
             Any keyword arguments that need to be passed to the plugin.
             Supported keywords are:
 
             test : bool, optional
-                Flag to indicate that the plugin should be executed in test mode.
-                This flag will prevent the plugin from storing any data to the
-                file system.
+                Flag to indicate that the plugin should be executed in test
+                mode. This flag will prevent the plugin from storing any
+                data to the file system.
         """
         _test_mode = kwargs.get("test", False)
         self.results = None
@@ -175,20 +172,22 @@ class WorkflowNode(GenericNode):
         for _child in self._children:
             _child.prepare_execution(**kwargs)
 
-    def execute_plugin(self, arg: Dataset | Integral, **kwargs: dict):
+    def execute_plugin(
+        self, arg: Dataset | int, **kwargs: Any
+    ) -> tuple[Dataset | float, dict]:
         """
         Execute the plugin associated with the node.
 
         Parameters
         ----------
-        arg : Dataset | Integral
+        arg : Dataset or int
             The argument which needs to be passed to the plugin.
-        **kwargs : dict
+        **kwargs : Any
             Any keyword arguments that need to be passed to the plugin.
 
         Returns
         -------
-        results : Dataset
+        results : Dataset or float
             The result of the plugin.execute method.
         kwargs : dict
             Any keywords required for calling the next plugin.
@@ -201,32 +200,41 @@ class WorkflowNode(GenericNode):
         self.runtime = _runtime()
         return _results, kwargs
 
-    def execute_plugin_chain(self, arg: Dataset | Integral, **kwargs: dict):
+    def execute_plugin_chain(self, arg: Dataset | int, **kwargs: Any) -> None:
         """
         Execute the full plugin chain recursively.
 
         This method will call the plugin.execute method and pass the results
         to the node's children and call their execute_plugin_chain methods.
         Note: No result callback is intended. It is assumed that plugin chains
-        are responsible for saving their own data at the end of the processing.
+        are responsible for saving their own data at the end of processing.
+
+        Uses copy-on-write strategy for multi-child nodes to minimize memory
+        usage by sharing data between siblings until a mutation is detected.
 
         Parameters
         ----------
-        arg : Dataset | Integral
+        arg : Dataset or int
             The argument which needs to be passed to the plugin.
-        **kwargs : dict
+        **kwargs : Any
             Any keyword arguments that need to be passed to the plugin.
         """
         res, reskws = self.execute_plugin(arg, **kwargs)
-        for _child in self._children:
-            if len(self._children) > 1:
-                _child.execute_plugin_chain(deepcopy(res), **reskws)
-            else:
-                _child.execute_plugin_chain(
-                    res, **self._get_deep_copy_of_kwargs(reskws)
-                )
+        if not self.children:
+            return
+        if self.n_children == 1:
+            # Single child path: pass directly without deep copying kwargs
+            self._children[0].execute_plugin_chain(
+                res, **self._get_deep_copy_of_kwargs(reskws)
+            )
+        else:
+            # Multi-child path: use copy-on-write strategy
+            for _child in self.children:
+                _child_kwargs = self._get_deep_copy_of_kwargs(reskws)
+                _child_data = res.copy()
+                _child.execute_plugin_chain(_child_data, **_child_kwargs)
 
-    def _store_results_if_required(self, results: Dataset, reskws: dict):
+    def _store_results_if_required(self, results: Dataset, reskws: dict) -> None:
         """
         Store the results of the plugin if required.
 
@@ -237,13 +245,18 @@ class WorkflowNode(GenericNode):
         reskws : dict
             The keyword arguments as returned from the plugin execution
         """
+        if self.plugin.output_data_dim is None:
+            return
         if (
             self.is_leaf
             or self.plugin.get_param_value("keep_results")
             or reskws.get("force_store_results", False)
-        ) and self.plugin.output_data_dim is not None:
-            self.results = deepcopy(results)
-            self.result_kws = self._get_deep_copy_of_kwargs(reskws)
+        ):
+            self.results = results
+            if self.is_leaf:
+                self.result_kws = reskws
+            else:
+                self.result_kws = self._get_deep_copy_of_kwargs(reskws)
 
     @staticmethod
     def _get_deep_copy_of_kwargs(kwargs: dict) -> dict:
@@ -293,18 +306,18 @@ class WorkflowNode(GenericNode):
         }
 
     @property
-    def result_shape(self) -> tuple[Integral] | None:
+    def result_shape(self) -> tuple[int, ...] | None:
         """
         Get the result shape of the plugin if it has already been calculated.
 
         Returns
         -------
-        tuple[Integral] | None
+        tuple[int, ...] or None
             Returns the shape of the Plugin's results, if it has been
             calculated. Else, returns None.
         """
         if isinstance(self.results, Dataset):
-            return self.results.shape
+            return self.results.shape  # type: ignore[return-value]
         if isinstance(self.results, Real):
             return (1,)
         return None
@@ -334,6 +347,6 @@ class WorkflowNode(GenericNode):
         Self
             The WorkflowNode instance copy.
         """
-        _copy = GenericNode.__copy__(self)
-        _copy.plugin.node_id = _copy.node_id
+        _copy = super().__copy__()
+        _copy.plugin.node_id = _copy.node_id  # noinspection PyUnresolvedAttribute
         return _copy

--- a/src/pydidas/workflow/workflow_node.py
+++ b/src/pydidas/workflow/workflow_node.py
@@ -204,6 +204,7 @@ class WorkflowNode(GenericNode):
             Any keywords required for calling the next plugin.
         """
         with TimerSaveRuntime() as _runtime:
+            self.clear_data()
             if kwargs.get("store_input_data", False):
                 self.plugin.store_input_data_copy(arg, **kwargs)
             _results, kwargs = self.plugin.execute(arg, **kwargs)
@@ -230,6 +231,7 @@ class WorkflowNode(GenericNode):
         **kwargs : Any
             Any keyword arguments that need to be passed to the plugin.
         """
+        self.clear_data(recursive=True)
         res, reskws = self.execute_plugin(arg, **kwargs)
         if not self.children:
             return
@@ -268,6 +270,24 @@ class WorkflowNode(GenericNode):
                 self.result_kws = reskws
             else:
                 self.result_kws = self._get_deep_copy_of_kwargs(reskws)
+
+    def clear_data(self, recursive: bool = False) -> None:
+        """
+        Clear the results of the plugin from the memory.
+
+        Parameters
+        ----------
+        recursive : bool, optional
+            Flag whether to clear the results of the child nodes as well. The
+            default is False.
+        """
+        self.results = None
+        self.result_kws = None
+        self.plugin._config["input_data"] = None
+        self.plugin._config["input_kwargs"] = {}
+        if recursive:
+            for _child in self._children:
+                _child.clear_data(recursive=True)
 
     @staticmethod
     def _get_deep_copy_of_kwargs(kwargs: dict) -> dict:

--- a/src/pydidas/workflow/workflow_node.py
+++ b/src/pydidas/workflow/workflow_node.py
@@ -50,9 +50,7 @@ class WorkflowNode(GenericNode):
 
     def __init__(self, **kwargs: Any):
         self.__preprocess_kwargs(kwargs)
-        GenericNode.__init__(self, **kwargs)
-        self.__confirm_plugin_existence_and_type()
-        self.node_id = self.__tmp_node_id
+        super().__init__(**kwargs)
         self.results = None
         self.result_kws = None
         self.runtime = -1
@@ -69,28 +67,40 @@ class WorkflowNode(GenericNode):
         kwargs : dict
             The calling keyword arguments from init.
         """
-        self.plugin = None
-        self.__tmp_node_id = kwargs.pop("node_id", None)
-
-    def __confirm_plugin_existence_and_type(self) -> None:
-        """
-        Verify that a plugin exists and is of the correct type.
-
-        Raises
-        ------
-        KeyError
-            If no plugin has been selected.
-        TypeError
-            If the plugin is not an instance of BasePlugin.
-        """
+        self._node_id: int | None = None
+        self._plugin: BasePlugin | None = None
+        self.plugin = kwargs.pop("plugin", None)
+        self.node_id = kwargs.get("node_id", None)
         if self.plugin is None:
             raise KeyError(
                 "No plugin has been supplied for the WorkflowNode. "
                 "The node has not been created."
             )
-        if not isinstance(self.plugin, BasePlugin):
+
+    @property
+    def plugin(self) -> BasePlugin:
+        """
+        Get the plugin of the node.
+
+        Returns
+        -------
+        BasePlugin
+            The plugin of the node.
+        """
+        return self._plugin
+
+    @plugin.setter
+    def plugin(self, new_plugin: BasePlugin):
+        """
+        Set the plugin of the node.
+        """
+        if new_plugin is None:
+            self._plugin = None
+            return
+        if not isinstance(new_plugin, BasePlugin):
             raise TypeError("Plugin must be an instance of BasePlugin (or subclass).")
-        self.plugin.node_id = self.__tmp_node_id
+        self._plugin = new_plugin
+        self._plugin.node_id = self.node_id
 
     @property
     def node_id(self) -> int | None:
@@ -127,7 +137,8 @@ class WorkflowNode(GenericNode):
                 "The new node_id is not of a correct type and has not been set."
             )
         self._node_id = new_id
-        self.plugin.node_id = new_id
+        if self.plugin:
+            self.plugin.node_id = new_id
 
     def consistency_check(self) -> bool:
         """
@@ -317,7 +328,7 @@ class WorkflowNode(GenericNode):
             calculated. Else, returns None.
         """
         if isinstance(self.results, Dataset):
-            return self.results.shape  # type: ignore[return-value]
+            return self.results.shape
         if isinstance(self.results, Real):
             return (1,)
         return None
@@ -338,15 +349,15 @@ class WorkflowNode(GenericNode):
         _hashes = tuple(hash(_item) for _item in _hashables)
         return hash(_hashes)
 
-    def __copy__(self) -> Self:
+    def __copy__(self) -> "WorkflowNode":
         """
-        Return a copy of the WorkflowNode.
+        Return a copy of the WorkflowNode instance.
 
         Returns
         -------
-        Self
+        WorkflowNode
             The WorkflowNode instance copy.
         """
-        _copy = super().__copy__()
-        _copy.plugin.node_id = _copy.node_id  # noinspection PyUnresolvedAttribute
+        _copy: Self = super().__copy__()
+        _copy.plugin.node_id = _copy.node_id
         return _copy

--- a/src/pydidas_plugins/proc_plugins/average_data_dimension.py
+++ b/src/pydidas_plugins/proc_plugins/average_data_dimension.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2024 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2024 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -20,11 +20,14 @@ Module with the Sum2dData Plugin which can be used to sum over 2D data.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2024 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2024 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
 __all__ = ["AverageDataDimension"]
+
+
+from typing import Any
 
 import numpy as np
 
@@ -45,7 +48,7 @@ class AverageDataDimension(ProcPlugin):
 
     default_params = get_generic_param_collection("process_data_dim")
 
-    def execute(self, data: Dataset, **kwargs: dict) -> tuple[Dataset, dict]:
+    def execute(self, data: Dataset, **kwargs: Any) -> tuple[Dataset, dict]:
         """
         Average over the given data dimension.
 
@@ -58,9 +61,9 @@ class AverageDataDimension(ProcPlugin):
 
         Returns
         -------
-        pydidas.core.Dataset
+        Dataset
             The data sum in form of an array of shape (1,).
-        kwargs : dict
+        kwargs : Any
             Any calling kwargs, appended by any changes in the function.
         """
         _res = data.mean(axis=self.get_param_value("process_data_dim"))

--- a/src/pydidas_plugins/proc_plugins/subtract_bg_image.py
+++ b/src/pydidas_plugins/proc_plugins/subtract_bg_image.py
@@ -145,6 +145,8 @@ class SubtractBackgroundImage(ProcPlugin):
                 f"Input data: {data.shape}\nBackground image: {self._bg_image.shape}"
             )
         _corrected_data = data - self._bg_image
+        if _corrected_data.dtype != data.dtype:
+            _corrected_data = _corrected_data.astype(data.dtype)
         if self._thresh is not None:
             _corrected_data[_corrected_data < self._thresh] = self._thresh
         return _corrected_data, kwargs

--- a/src/pydidas_plugins/proc_plugins/subtract_bg_image.py
+++ b/src/pydidas_plugins/proc_plugins/subtract_bg_image.py
@@ -135,7 +135,7 @@ class SubtractBackgroundImage(ProcPlugin):
         -------
         _corrected_data : Dataset
             The image data.
-        kwargs : dict
+        **kwargs : Any
             Any calling kwargs, appended by any changes in the function.
         """
         if data.shape != self._bg_image.shape:
@@ -146,19 +146,17 @@ class SubtractBackgroundImage(ProcPlugin):
             )
         _corrected_data = data - self._bg_image
         if self._thresh is not None:
-            _corrected_data = np.where(
-                _corrected_data < self._thresh, self._thresh, _corrected_data
-            )
+            _corrected_data[_corrected_data < self._thresh] = self._thresh
         return _corrected_data, kwargs
 
-    def get_parameter_config_widget(self) -> QtWidgets.QWidget:
+    def get_parameter_config_widget(self) -> type[QtWidgets.QWidget]:
         """
         Get the unique configuration widget associated with this Plugin.
 
         Returns
         -------
-        QtWidgets.QWidget
-            The unique ParameterConfig widget
+        type[QtWidgets.QWidget]
+            The unique ParameterConfig widget for the SubtractBackgroundImage plugin.
         """
         return SubtractBackgroundImageConfigWidget
 
@@ -179,10 +177,11 @@ class SubtractBackgroundImageConfigWidget(GenericPluginConfigWidget):
         )
 
     def finalize_init(self) -> None:
+        """Initialize the configuration widget."""
         self._toggle_hdf5_plugin_visibility(self.plugin.get_param_value("bg_file"))
 
     @QtCore.Slot(str)
-    def _toggle_hdf5_plugin_visibility(self, new_file: str):
+    def _toggle_hdf5_plugin_visibility(self, new_file: str) -> None:
         """
         Toggle the visibility of the plugins for Hdf5 dataset and frame number.
 

--- a/tests/_plugin_tests/proc_plugins/test_subtract_bg_image.py
+++ b/tests/_plugin_tests/proc_plugins/test_subtract_bg_image.py
@@ -133,17 +133,21 @@ def test_pre_execute__outputs(temp_path, multiplicator, threshold, ROI, use_roi)
 @pytest.mark.parametrize("multiplicator", [0.1, 1.0, 2.5])
 @pytest.mark.parametrize("threshold", [None, -1, 0, 1.5])
 def test_execute(temp_path, bg_image_dtype, data_dtype, multiplicator, threshold):
+    if data_dtype == np.uint16 and threshold == -1:
+        return
+        # skip this test because the threshold is invalid for uint data
     plugin = SubtractBackgroundImage()
     image_file = get_image_file(temp_path, "test.npy", bg_image_dtype)
     plugin.set_param_value("bg_file", image_file)
     plugin.set_param_value("multiplicator", multiplicator)
     plugin.set_param_value("threshold_low", threshold)
     plugin.pre_execute()
-    _data = np.ones(_IMAGE.shape, dtype=data_dtype) * 400
+    _data = np.ones(_IMAGE.shape, dtype=data_dtype) * 1500
     _res, _kws = plugin.execute(_data)
-    _ref = _data - multiplicator * _IMAGE
+    _ref = (_data - multiplicator * _IMAGE).astype(data_dtype)
     if threshold is not None:
-        _ref = np.where(_ref < threshold, threshold, _ref)
+        _ref = np.where(_ref < threshold, threshold, _ref).astype(data_dtype)
+    assert _res.dtype == data_dtype
     assert np.allclose(_res, _ref)
 
 

--- a/tests/_plugin_tests/proc_plugins/test_subtract_bg_image.py
+++ b/tests/_plugin_tests/proc_plugins/test_subtract_bg_image.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -20,7 +20,7 @@ Tests for the SubtractBackgroundImage plugin.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2025 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Development"

--- a/tests/core/test_object_with_parameter_collection.py
+++ b/tests/core/test_object_with_parameter_collection.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -18,7 +18,7 @@
 """Unit tests for pydidas modules."""
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -354,7 +354,7 @@ class TestObjectWithParameterCollection(unittest.TestCase):
         self.assertIsInstance(obj2, ObjectWithParameterCollection)
         self.assertNotEqual(id(obj), id(obj2))
 
-    def test_explicity_copy(self):
+    def test_copy__w_config(self):
         obj = ObjectWithParameterCollection()
         obj.add_params(self._params)
         obj._config = {"a": "123", "b": [1, 2, 3], "c": ("A", "C")}
@@ -392,7 +392,7 @@ class TestObjectWithParameterCollection(unittest.TestCase):
         for _key, _val in obj.param_values.items():
             self.assertEqual(_val, obj2.get_param_value(_key))
 
-    def test_explicity_deepcopy(self):
+    def test_deepcopy(self):
         obj = ObjectWithParameterCollection()
         obj.add_params(self._params)
         obj._config = {"a": 123, "b": [1, 2, 3], "c": ("A", "C")}

--- a/tests/workflow/test_generic_node.py
+++ b/tests/workflow/test_generic_node.py
@@ -248,6 +248,23 @@ class TestGenericNode(unittest.TestCase):
         _ids = root.get_recursive_ids()
         self.assertEqual(_ids, [0])
 
+    def test_reset_all_node_ids__no_children(self):
+        root = GenericNode(node_id=0)
+        root.reset_all_node_ids()
+        self.assertIsNone(root.node_id)
+
+    def test_reset_all_node_ids__w_children(self):
+        _nodes, _target_conns, _n_nodes = self.create_node_tree()
+        _all_node_ids = _nodes[0][0].get_recursive_ids()
+        _node_child_ids = _nodes[1][0].get_recursive_ids()
+        _valid_ids = [_id for _id in _all_node_ids if _id not in _node_child_ids]
+        _nodes[1][0].reset_all_node_ids()
+        for _tier in _nodes:
+            for _node in _tier:
+                _node_id = _node.node_id
+                if _node_id not in _valid_ids:
+                    self.assertIsNone(_node_id)
+
     def test_delete_node_references__no_children_not_recursive(self):
         root = GenericNode(node_id=0)
         node = GenericNode(node_id=1, parent=root)

--- a/tests/workflow/test_generic_node.py
+++ b/tests/workflow/test_generic_node.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2024, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -18,7 +18,7 @@
 """Unit tests for pydidas modules."""
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2024, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -270,12 +270,22 @@ class TestGenericNode(unittest.TestCase):
             _nodes[1][0].delete_node_references(recursive=False)
 
     def test_delete_node_references__with_children_recursive(self):
-        _nodes, _target_conns, _n_nodes = self.create_node_tree(5, 1)
+        _nodes, _target_conns, _n_nodes = self.create_node_tree(5, 2)
         _root = _nodes[0][0]
-        _nodes[1][0].delete_node_references(recursive=True)
-        self.assertFalse(_nodes[1][0] in _root._children)
-        self.assertEqual(_nodes[1][0].n_children, 0)
-        self.assertIsNone(_nodes[2][0].parent)
+        _child = _nodes[1][0]
+        _child_ids = _child.get_recursive_ids()
+        _child.delete_node_references(recursive=True)
+        for _tier, _tiernodes in enumerate(_nodes):
+            for _node in _tiernodes:
+                _node_id = _node.node_id
+                if _node_id == 0:
+                    self.assertNotIn(_child, _root.children)
+                elif _node_id in _child_ids:
+                    self.assertIsNone(_node.parent)
+                    self.assertEqual(_node.children, [])
+                else:
+                    self.assertIsNotNone(_node.parent)
+                    self.assertEqual(_node.n_children, 2 if _tier <= 4 else 0)
 
     def test_connect_parent_to_children__no_parent_no_children(self):
         root = GenericNode(node_id=0)

--- a/tests/workflow/test_generic_node.py
+++ b/tests/workflow/test_generic_node.py
@@ -203,6 +203,14 @@ class TestGenericNode(unittest.TestCase):
         obj._children = _children
         self.assertEqual(obj.get_children(), _children)
 
+    def test_get_children__recursively(self):
+        _nodes, _target_conns, _n_nodes = self.create_node_tree()
+        _children = _nodes[0][0].get_children(recursive=True)
+        for _tier in _nodes:
+            for _node in _tier:
+                if _node != _nodes[0][0]:
+                    self.assertIn(_node, _children)
+
     def test_set_parent(self):
         _parent = GenericNode()
         obj = GenericNode()

--- a/tests/workflow/test_generic_tree.py
+++ b/tests/workflow/test_generic_tree.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -18,7 +18,7 @@
 """Unit tests for pydidas modules."""
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"

--- a/tests/workflow/test_generic_tree.py
+++ b/tests/workflow/test_generic_tree.py
@@ -66,7 +66,7 @@ class TestGenericTree(unittest.TestCase):
         tree = GenericTree()
         tree.nodes = dict(a=1, b="c")
         tree.node_ids = [0, 1]
-        tree.root = 12
+        tree.root = GenericNode()
         tree.clear()
         self.assertEqual(tree.nodes, {})
         self.assertEqual(tree.node_ids, [])
@@ -260,9 +260,11 @@ class TestGenericTree(unittest.TestCase):
         node = GenericNode(node_id=0)
         child = GenericNode(parent=node)
         tree.register_node(node)
+        self.assertEqual(tree.nodes, {0: node, 1: child})
         tree.delete_node_by_id(0, recursive=False, keep_children=True)
         self.assertFalse(node in tree.nodes.values())
         self.assertIsNone(child.parent)
+        self.assertEqual(node.n_children, 0)
         self.assertEqual(tree.root, child)
         self.assertEqual(tree.nodes, {1: child})
 
@@ -429,7 +431,7 @@ class TestGenericTree(unittest.TestCase):
             self.assertFalse(_node in _copy.nodes.values())
         for _node in _copy.root._children:
             self.assertTrue(_node in _copy.nodes.values())
-        for key in set(tree.__dict__.keys()) - {"root", "nodes", "_start_hash"}:
+        for key in set(tree.__dict__.keys()) - {"_root", "nodes", "_start_hash"}:
             self.assertEqual(getattr(tree, key), getattr(_copy, key))
 
     def test_copy(self):
@@ -439,7 +441,7 @@ class TestGenericTree(unittest.TestCase):
         _nodes, _n_nodes = self.create_node_tree(depth=_depth, width=_width)
         tree.register_node(_nodes[0][0])
         _copy = tree.copy()
-        for _key in ["root", "nodes", "_start_hash", "node_ids", "_config"]:
+        for _key in ["_root", "nodes", "_start_hash", "node_ids", "_config"]:
             self.assertIn(_key, _copy.__dict__.keys())
         for _node in tree.nodes.values():
             self.assertFalse(_node in _copy.nodes.values())
@@ -455,7 +457,7 @@ class TestGenericTree(unittest.TestCase):
         _copy = tree.copy(as_type=TestTree)
         self.assertIsInstance(_copy, TestTree)
         self.assertIsInstance(_copy, GenericTree)
-        for _key in ["root", "nodes", "_start_hash", "node_ids", "_config"]:
+        for _key in ["_root", "nodes", "_start_hash", "node_ids", "_config"]:
             self.assertIn(_key, _copy.__dict__.keys())
         for _node in tree.nodes.values():
             self.assertFalse(_node in _copy.nodes.values())
@@ -466,7 +468,7 @@ class TestGenericTree(unittest.TestCase):
         _copy = tree.copy()
         self.assertIsInstance(_copy, GenericTree)
         self.assertEqual(tree.dummy, _copy.dummy)
-        for _key in ["root", "nodes", "_start_hash", "node_ids", "_config"]:
+        for _key in ["_root", "nodes", "_start_hash", "node_ids", "_config"]:
             self.assertIn(_key, _copy.__dict__.keys())
 
     def test_hash___empty_tree(self):

--- a/tests/workflow/test_generic_tree.py
+++ b/tests/workflow/test_generic_tree.py
@@ -354,6 +354,7 @@ class TestGenericTree(unittest.TestCase):
         _child2 = tree.root.get_children()[1]
         _id2 = _child2.node_id
         _original_ids = set(tree.node_ids)
+        tree.active_node_id = _child2.node_id
         tree.change_node_parent(_child2.node_id, _child1.node_id)
         _new_ids = set(tree.node_ids)
         self.assertTrue(tree.tree_has_changed)
@@ -363,6 +364,7 @@ class TestGenericTree(unittest.TestCase):
         self.assertEqual(_original_ids, _new_ids)
         self.assertEqual(_child1.node_id, _id1)
         self.assertEqual(_child2.node_id, _id2)
+        self.assertEqual(tree.active_node, _child2)
 
     def test_change_node_parent__swap_ids(self):
         tree = GenericTree()
@@ -373,6 +375,7 @@ class TestGenericTree(unittest.TestCase):
         _child2 = tree.root.get_children()[1]
         _id2 = _child2.node_id
         _original_ids = set(tree.node_ids)
+        tree.active_node_id = _child2.node_id
         tree.change_node_parent(_child1.node_id, _child2.node_id)
         _new_ids = set(tree.node_ids)
         self.assertTrue(tree.tree_has_changed)
@@ -382,6 +385,7 @@ class TestGenericTree(unittest.TestCase):
         self.assertEqual(_original_ids, _new_ids)
         self.assertEqual(_child1.node_id, _id2)
         self.assertEqual(_child2.node_id, _id1)
+        self.assertEqual(tree.active_node, _child2)
 
     def test_order_node_ids__empty_tree(self):
         tree = GenericTree()

--- a/tests/workflow/test_processing_tree.py
+++ b/tests/workflow/test_processing_tree.py
@@ -315,7 +315,7 @@ class TestProcessingTree(unittest.TestCase):
         for _node in tree2.root._children:
             self.assertTrue(_node in tree2.nodes.values())
         for key in set(self._curr_tree.__dict__.keys()) - {
-            "root",
+            "_root",
             "nodes",
             "_start_hash",
         }:

--- a/tests/workflow/test_processing_tree.py
+++ b/tests/workflow/test_processing_tree.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -18,7 +18,7 @@
 """Unit tests for pydidas modules."""
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -415,7 +415,7 @@ class TestProcessingTree(unittest.TestCase):
         self.assertEqual(self._curr_tree.nodes, dict())
 
     def test_get_complete_plugin_metadata__empty_tree(self):
-        _meta = self._curr_tree.get_complete_plugin_metadata()
+        _meta = self._curr_tree.get_plugin_metadata("all")
         self.assertEqual(list(_meta["shapes"].keys()), [])
         self.assertIsInstance(_meta, dict)
         for _key in ["shapes", "labels", "names", "data_labels", "result_titles"]:
@@ -424,7 +424,7 @@ class TestProcessingTree(unittest.TestCase):
     def test_get_complete_plugin_metadata__populated_tree__no_results(self):
         _nodes, _index = self.create_node_tree(width=1, depth=3)
         self._curr_tree.set_root(_nodes[0][0])
-        _meta = self._curr_tree.get_complete_plugin_metadata()
+        _meta = self._curr_tree.get_plugin_metadata("all")
         self.assertEqual(list(_meta["shapes"].keys()), [])
 
     def test_get_complete_plugin_metadata__populated_tree__w_single_result(self):
@@ -432,7 +432,7 @@ class TestProcessingTree(unittest.TestCase):
         self._curr_tree.set_root(_nodes[0][0])
         self._curr_tree.prepare_execution()
         self._curr_tree.execute_process(0)
-        _meta = self._curr_tree.get_complete_plugin_metadata()
+        _meta = self._curr_tree.get_plugin_metadata("all")
         self.assertEqual(list(_meta["shapes"].keys()), [3])
         self.assertEqual(self._curr_tree.nodes[3].result_shape, _meta["shapes"][3])
 
@@ -441,7 +441,7 @@ class TestProcessingTree(unittest.TestCase):
         self._curr_tree.set_root(_nodes[0][0])
         self._curr_tree.prepare_execution()
         self._curr_tree.execute_process(0, force_store_results=True)
-        _meta = self._curr_tree.get_complete_plugin_metadata()
+        _meta = self._curr_tree.get_plugin_metadata("all")
         self.assertEqual(
             list(_meta["shapes"].keys()), list(self._curr_tree.nodes.keys())
         )

--- a/tests/workflow/test_workflow_node.py
+++ b/tests/workflow/test_workflow_node.py
@@ -331,6 +331,87 @@ def test_hash_differs_on_config_change(
         assert hash(_item1) != hash(_item2)
 
 
+def test_clear_data_():
+    obj = WorkflowNode(plugin=DummyLoader())
+    obj.results = np.random.random((10, 10))
+    obj.result_kws = {"key": "value"}
+    obj.plugin._config["input_data"] = np.random.random((5, 5))
+    obj.plugin._config["input_kwargs"] = {"test": "data"}
+    obj.clear_data()
+    assert obj.results is None
+    assert obj.result_kws is None
+    assert obj.plugin._config["input_data"] is None
+    assert obj.plugin._config["input_kwargs"] == {}
+
+
+def test_clear_data__non_recursive_only_clears_self():
+    """Test that non-recursive clear_data does not affect children."""
+    nodes = create_node_tree(depth=2, width=2)
+    _root = nodes[0]
+    _root.results = np.random.random((10, 10))
+    _root.result_kws = {"root": "data"}
+    for _child in [nodes[1], nodes[2]]:
+        _child.results = np.random.random((10, 10))
+        _child.result_kws = {f"child{_child.node_id}": "data"}
+    _root.clear_data(recursive=False)
+    assert _root.results is None
+    assert _root.result_kws is None
+    for _child in [nodes[1], nodes[2]]:
+        assert _child.results is not None
+        assert _child.result_kws is not None
+
+
+def test_clear_data__recursive_clears_all():
+    """Test that recursive clear_data clears root and all descendants."""
+    nodes = create_node_tree(depth=2, width=2)
+    _root = nodes[0]
+    for _node in nodes.values():
+        _node.results = np.random.random((10, 10))
+        _node.result_kws = {"key": "value"}
+        _node.plugin._config["input_data"] = np.random.random((5, 5))
+        _node.plugin._config["input_kwargs"] = {"test": "data"}
+    _root.clear_data(recursive=True)
+    for _node in nodes.values():
+        assert _node.results is None
+        assert _node.result_kws is None
+        assert _node.plugin._config["input_data"] is None
+        assert _node.plugin._config["input_kwargs"] == {}
+
+
+def test_clear_data__recursive_intermediate_node():
+    """Test recursive clear_data from intermediate node and its descendants."""
+    nodes = create_node_tree(depth=3, width=2)
+    _root = nodes[0]
+    for _node in nodes.values():
+        _node.results = np.random.random((10, 10))
+        _node.result_kws = {"key": "value"}
+    _intermediate = _root.children[0]
+    _intermediate.clear_data(recursive=True)
+    assert _root.results is not None
+    assert _root.result_kws is not None
+    assert _intermediate.results is None
+    assert _intermediate.result_kws is None
+    for _child in _intermediate.children:
+        assert _child.results is None
+        assert _child.result_kws is None
+
+
+def test_clear_data__repeat_calls():
+    """Test that calling clear_data multiple times is safe."""
+    obj = WorkflowNode(plugin=DummyLoader())
+    obj.results = np.random.random((10, 10))
+    obj.result_kws = {"key": "value"}
+    obj.plugin._config["input_data"] = np.random.random((5, 5))
+    obj.plugin._config["input_kwargs"] = {"test": "data"}
+    obj.clear_data()
+    assert obj.results is None
+    obj.clear_data()
+    assert obj.results is None
+    assert obj.result_kws is None
+    assert obj.plugin._config["input_data"] is None
+    assert obj.plugin._config["input_kwargs"] == {}
+
+
 # ---------------------
 # - Integration tests -
 # ---------------------
@@ -338,10 +419,8 @@ def test_delete_note_references():
     """Test delete_note_references with children."""
     nodes = create_node_tree()
     _root = nodes[0]
-    print("\nRoot children", _root.children)
     _root.delete_node_references(recursive=True)
     for _id, _node in nodes.items():
-        print(_id, _node.children)
         assert _node.parent is None
         assert _node.children == []
 

--- a/tests/workflow/test_workflow_node.py
+++ b/tests/workflow/test_workflow_node.py
@@ -441,7 +441,7 @@ def test_connect_parent_to_children():
     assert nodes[1].children == [nodes[2]]
     nodes[1].connect_parent_to_children()
     assert nodes[1].children == []
-    assert nodes[1].parent == None
+    assert nodes[1].parent is None
     assert nodes[0].children == [nodes[2]]
     assert nodes[2].parent == nodes[0]
 

--- a/tests/workflow/test_workflow_node.py
+++ b/tests/workflow/test_workflow_node.py
@@ -456,5 +456,12 @@ def test_change_node_parent():
     assert nodes[3] in nodes[2].children
 
 
+def test_reset_all_node_ids():
+    nodes = create_node_tree(depth=2, width=2)
+    nodes[0].reset_all_node_ids()
+    for _node in nodes.values():
+        assert _node.node_id is None
+        assert _node.plugin.node_id is None
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/workflow/test_workflow_node.py
+++ b/tests/workflow/test_workflow_node.py
@@ -24,10 +24,10 @@ __maintainer__ = "Malte Storm"
 __status__ = "Production"
 
 
-import unittest
 from typing import Any
 
 import numpy as np
+import pytest
 
 from pydidas.contexts import DiffractionExperimentContext
 from pydidas.core import Dataset
@@ -47,256 +47,289 @@ class _PluginModifyInPlace(DummyProc):
         return data, kwargs
 
 
-class TestWorkflowNode(unittest.TestCase):
-    def setUp(self): ...
+def create_node_tree(
+    depth: int = 3,
+    width: int = 3,
+    root: WorkflowNode | None = None,
+    node_register: dict | None = None,
+) -> tuple:
+    """
+    Create a node tree for testing.
 
-    def tearDown(self): ...
+    Parameters
+    ----------
+    depth : int
+        The depth of the tree.
+    width : int
+        The branching width of the tree.
+    root : WorkflowNode or None
+        The root of the tree.
+    node_register : dict or None
+        A dictionary to register nodes by their node_id.
 
-    def create_node_tree(self, depth=3, width=3):
-        obj00 = WorkflowNode(node_id=0, plugin=DummyLoader())
-        _nodes = [[obj00]]
-        _index = 1
-        for _depth in range(depth):
-            _tiernodes = []
-            for _parent in _nodes[_depth]:
-                for _ichild in range(width):
-                    _node = WorkflowNode(node_id=_index, plugin=DummyProc())
-                    _parent.add_child(_node)
-                    _index += 1
-                    _tiernodes.append(_node)
-            _nodes.append(_tiernodes)
-        return _nodes, _index
+    Returns
+    -------
+    tuple
+        The node tree and the total number of nodes created.
+    """
+    if root is None:
+        root = WorkflowNode(node_id=0, plugin=DummyLoader())
+        node_register = {0: root}
+    _this_tier = []
+    for _ in range(width):
+        _index = max(node_register) + 1
+        _node = WorkflowNode(node_id=_index, plugin=DummyProc())
+        root.add_child(_node)
+        node_register[_node.node_id] = _node
+        _this_tier.append(_node)
 
-    def test_init__plugin_node_id(self):
-        _node_id = 42
-        obj = WorkflowNode(plugin=DummyLoader(), node_id=_node_id)
-        self.assertEqual(obj.plugin.node_id, _node_id)
+    if depth > 0:
+        for _node in _this_tier:
+            node_register = create_node_tree(
+                depth=depth - 1, width=width, root=_node, node_register=node_register
+            )
+    return node_register
 
-    def test_copy(self):
-        _node_id = 42
-        obj = WorkflowNode(plugin=DummyLoader(), node_id=_node_id)
-        obj.plugin.set_param_value("binning", 3)
-        new = obj.copy()
-        self.assertEqual(new.plugin.node_id, _node_id)
-        self.assertEqual(obj.plugin.node_id, _node_id)
 
-    def test_copy__with_EXP_property(self):
-        _node_id = 42
-        obj = WorkflowNode(plugin=DummyLoader(), node_id=_node_id)
-        obj.plugin._EXP = EXP
-        new = obj.copy()
-        self.assertEqual(new.plugin.node_id, _node_id)
-        self.assertEqual(obj.plugin.node_id, _node_id)
-        self.assertEqual(obj.plugin._EXP, EXP)
-        self.assertEqual(new.plugin._EXP, EXP)
+def test_init():
+    """Test that plugin node_id is set correctly during initialization."""
+    _node_id = 42
+    obj = WorkflowNode(plugin=DummyLoader(), node_id=_node_id)
+    assert obj.plugin.node_id == _node_id
+    assert obj.results is None
 
-    def test_node_id_property__get(self):
-        obj = WorkflowNode(plugin=DummyLoader())
-        self.assertIsNone(obj.node_id)
 
-    def test_node_id_property__get_int(self):
-        _id = 12
-        obj = WorkflowNode(plugin=DummyLoader(), node_id=_id)
-        self.assertEqual(obj.node_id, _id)
+def test_copy():
+    """Test that copying a WorkflowNode preserves node_id."""
+    _node_id = 42
+    obj = WorkflowNode(plugin=DummyLoader(), node_id=_node_id)
+    obj.plugin.set_param_value("binning", 3)
+    new = obj.copy()
+    assert new.plugin.node_id == _node_id
+    assert obj.plugin.node_id == _node_id
+    assert new.plugin.get_param_value("binning") == 3
 
-    def test_node_id_property__set_int(self):
-        _id = 12
-        obj = WorkflowNode(plugin=DummyLoader())
-        obj.node_id = _id
-        self.assertEqual(obj._node_id, _id)
-        self.assertEqual(obj.plugin.node_id, _id)
 
-    def test_result_shape__not_set(self):
-        obj = WorkflowNode(plugin=DummyLoader())
-        self.assertIsNone(obj.result_shape)
+def test_copy__with_EXP_property():
+    """Test that copying preserves _EXP property."""
+    _node_id = 42
+    obj = WorkflowNode(plugin=DummyLoader(), node_id=_node_id)
+    obj.plugin._EXP = EXP
+    new = obj.copy()
+    assert new.plugin.node_id == _node_id
+    assert obj.plugin.node_id == _node_id
+    assert obj.plugin._EXP == EXP
+    assert new.plugin._EXP == EXP
 
-    def test_result_shape(self):
-        obj = WorkflowNode(plugin=DummyLoader())
+
+@pytest.mark.parametrize("node_id", [None, 12, 42])
+def test_node_id_property_get(node_id):
+    """Test getting node_id property with various values."""
+    obj = WorkflowNode(plugin=DummyLoader(), node_id=node_id)
+    assert obj.node_id == node_id
+
+
+@pytest.mark.parametrize("initial_id, new_id", [(None, 12), (5, 20), (42, 99)])
+def test_node_id_property_set(initial_id, new_id):
+    """Test setting node_id property syncs with plugin."""
+    obj = WorkflowNode(plugin=DummyLoader(), node_id=initial_id)
+    obj.node_id = new_id
+    assert obj._node_id == new_id
+    assert obj.plugin.node_id == new_id
+
+
+@pytest.mark.parametrize("keep_results, expected", [(False, None), (True, (10, 10))])
+def test_result_shape(keep_results, expected):
+    """Test result_shape property with various configurations."""
+    obj = WorkflowNode(plugin=DummyLoader())
+    if keep_results:
         obj.plugin.set_param_value("keep_results", True)
         obj.execute_plugin(0)
-        self.assertEqual(obj.result_shape, (10, 10))
+    assert obj.result_shape == expected
 
-    def test_dump(self):
+
+def test_dump():
+    """Test dump method returns dict with required keys."""
+    obj = WorkflowNode(plugin=DummyLoader())
+    _dump = obj.dump()
+    assert isinstance(_dump, dict)
+    for key in ("node_id", "parent", "children", "plugin_class", "plugin_params"):
+        assert key in _dump.keys()
+
+
+def test_execute_plugin_chain__w_plugin_modify_in_place():
+    """Test execute_plugin_chain with plugins modifying data in place."""
+    root = WorkflowNode(node_id=0, plugin=DummyLoader())
+    child1 = WorkflowNode(node_id=1, plugin=_PluginModifyInPlace())
+    child2 = WorkflowNode(node_id=2, plugin=_PluginModifyInPlace())
+    child3 = WorkflowNode(node_id=3, plugin=DummyProc())
+    root.add_child(child1)
+    root.add_child(child2)
+    root.add_child(child3)
+    root.execute_plugin_chain(0, force_store_results=True, offset=3)
+    _root_data = root.results
+    _child1_data = child1.results
+    _child2_data = child2.results
+    _child3_data = child3.results
+    assert np.all(_root_data > 0)
+    assert np.allclose(_root_data + 3, _child3_data)
+    assert np.allclose(_child1_data[0], 1)
+    assert np.allclose(_child2_data[0], 2)
+    for _key, _node in [[1, child1], [2, child2], ["offset_03", child3]]:
+        assert set(_node.result_kws) == {_key, "offset", "index", "force_store_results"}
+
+
+@pytest.mark.parametrize("force_store", [False, True])
+def test_execute_plugin_chain__w_store_results(force_store):
+    _depth = 3
+    nodes = create_node_tree(depth=_depth)
+    root = nodes[0]
+    root.execute_plugin_chain(0, force_store_results=force_store)
+    for _id, _node in nodes.items():
+        if force_store or _node.is_leaf:
+            assert _node.results is not None
+            assert _node.result_kws is not None
+        else:
+            assert _node.results is None
+            assert _node.result_kws is None
+
+
+@pytest.mark.parametrize(
+    "input_data,is_loader", [(0, True), (np.random.random((10, 10)), False)]
+)
+def test_execute_plugin_results(input_data, is_loader):
+    """Test execute_plugin result types with different inputs."""
+    if is_loader:
         obj = WorkflowNode(plugin=DummyLoader())
-        _dump = obj.dump()
-        self.assertIsInstance(_dump, dict)
-        for key in ("node_id", "parent", "children", "plugin_class", "plugin_params"):
-            self.assertTrue(key in _dump.keys())
-
-    def test_execute_plugin_chain__w_plugin_modify_in_place(self):
-        root = WorkflowNode(node_id=0, plugin=DummyLoader())
-        child1 = WorkflowNode(node_id=1, plugin=_PluginModifyInPlace())
-        child2 = WorkflowNode(node_id=2, plugin=_PluginModifyInPlace())
-        child3 = WorkflowNode(node_id=3, plugin=DummyProc())
-        root.add_child(child1)
-        root.add_child(child2)
-        root.add_child(child3)
-        root.execute_plugin_chain(0, force_store_results=True, offset=3)
-        _root_data = root.results
-        _child1_data = child1.results
-        _child2_data = child2.results
-        _child3_data = child3.results
-        self.assertTrue(np.all(_root_data > 0))
-        self.assertTrue(np.allclose(_root_data + 3, _child3_data))
-        self.assertTrue(np.allclose(_child1_data[0], 1))
-        self.assertTrue(np.allclose(_child2_data[0], 2))
-        for _key, _node in [[1, child1], [2, child2], ["offset_03", child3]]:
-            self.assertEqual(
-                set(_node.result_kws), {_key, "offset", "index", "force_store_results"}
-            )
-
-    def test_execute_plugin_chain(self):
-        _depth = 3
-        nodes, n_nodes = self.create_node_tree(depth=_depth)
-        obj = nodes[0][0]
-        obj.execute_plugin_chain(0)
-        for _node in nodes[_depth]:
-            self.assertIsNotNone(_node.results)
-            self.assertIsNotNone(_node.result_kws)
-        for _d in range(_depth):
-            for _node in nodes[_d]:
-                self.assertIsNone(_node.results)
-                self.assertIsNone(_node.result_kws)
-
-    def test_execute_plugin_chain__with_force_store(self):
-        _depth = 3
-        nodes, n_nodes = self.create_node_tree(depth=_depth)
-        obj = nodes[0][0]
-        obj.execute_plugin_chain(0, force_store_results=True)
-        for _d in range(_depth + 1):
-            for _node in nodes[_d]:
-                self.assertIsNotNone(_node.results)
-                self.assertIsNotNone(_node.result_kws)
-
-    def test_execute_plugin_chain__with_store_input_data(self):
-        _depth = 3
-        nodes, n_nodes = self.create_node_tree(depth=_depth)
-        obj = nodes[0][0]
-        obj.execute_plugin_chain(0, force_store_results=True)
-        for _d in range(_depth + 1):
-            for _node in nodes[_d]:
-                self.assertIsNotNone(_node.results)
-                self.assertIsNotNone(_node.result_kws)
-
-    def test_execute_plugin__simple(self):
-        obj = WorkflowNode(plugin=DummyLoader())
-        _res = obj.execute_plugin(0)
-        self.assertIsInstance(_res[1], dict)
-
-    def test_execute_plugin__array_input(self):
-        _input = np.random.random((10, 10))
+    else:
         obj = WorkflowNode(plugin=DummyProc())
-        _res = obj.execute_plugin(_input)
-        self.assertIsInstance(_res[0], np.ndarray)
-        self.assertEqual(_input.shape, _res[0].shape)
+    _res = obj.execute_plugin(input_data)
+    assert isinstance(_res[1], dict)
+    if not is_loader:
+        assert isinstance(_res[0], np.ndarray)
 
-    def test_execute_plugin__single_in_tree(self):
-        nodes, n_nodes = self.create_node_tree()
-        obj = nodes[1][1]
-        _res = obj.execute_plugin(0)
-        self.assertIsInstance(_res[1], dict)
 
-    def test_prepare_execution(self):
-        _depth = 3
-        nodes, n_nodes = self.create_node_tree(depth=_depth)
-        obj = nodes[0][0]
-        obj.prepare_execution()
-        for _d in range(_depth + 1):
-            for _node in nodes[_d]:
-                self.assertTrue(_node.plugin._pre_executed)
+def test_execute_plugin__simple():
+    """Test simple plugin execution with DummyLoader."""
+    _node = WorkflowNode(plugin=DummyLoader())
+    _res = _node.execute_plugin(0)
+    assert isinstance(_res[1], dict)
 
-    def test_confirm_plugin_existance_and_type__no_plugin(self):
-        with self.assertRaises(KeyError):
-            WorkflowNode()
 
-    def test_confirm_plugin_existance_and_type__wrong_plugin(self):
-        with self.assertRaises(TypeError):
-            WorkflowNode(plugin=12)
+def test_execute_plugin__array_input():
+    """Test plugin execution preserves array shape."""
+    _input = np.random.random((10, 10))
+    _node = WorkflowNode(plugin=DummyProc())
+    _res = _node.execute_plugin(_input)
+    assert isinstance(_res[0], np.ndarray)
+    assert _input.shape == _res[0].shape
 
-    def test_confirm_plugin_existance_and_type__correct_plugin(self):
-        obj = WorkflowNode(plugin=DummyLoader())
-        self.assertIsInstance(obj, WorkflowNode)
 
-    def test_consistency_check__no_parent(self):
-        obj = WorkflowNode(plugin=DummyLoader())
-        self.assertTrue(obj.consistency_check())
+def test_execute_plugin__single_in_tree():
+    """Test plugin execution within a node tree."""
+    nodes = create_node_tree()
+    _node = nodes[1]
+    _res, _kws = _node.execute_plugin(0)
+    assert isinstance(_res, (float, Dataset))
+    assert isinstance(_kws, dict)
 
-    def test_consistency_check__parent_out_any(self):
-        obj = WorkflowNode(plugin=DummyLoader())
-        obj2 = WorkflowNode(plugin=DummyProc(), parent=obj)
-        obj.plugin.base_output_data_dim = 2
-        obj2.plugin.input_data_dim = 2
-        self.assertTrue(obj2.consistency_check())
 
-    def test_consistency_check__plugin_in_any(self):
-        obj = WorkflowNode(plugin=DummyLoader())
-        obj2 = WorkflowNode(plugin=DummyProc(), parent=obj)
-        obj.plugin.input_data_dim = 2
-        obj2.plugin.input_data_dim = -1
-        self.assertTrue(obj2.consistency_check())
+# Prepare execution test
 
-    def test_consistency_check__eq_dims(self):
-        obj = WorkflowNode(plugin=DummyLoader())
-        obj2 = WorkflowNode(plugin=DummyProc(), parent=obj)
-        obj.plugin.input_data_dim = 2
-        obj2.plugin.input_data_dim = 2
-        self.assertTrue(obj2.consistency_check())
 
-    def test_consistency_check__neq_dims(self):
-        obj = WorkflowNode(plugin=DummyLoader())
-        obj2 = WorkflowNode(plugin=DummyProc(), parent=obj)
-        obj.plugin.input_data_dim = 2
-        obj2.plugin.input_data_dim = 1
-        self.assertFalse(obj2.consistency_check())
+def test_prepare_execution():
+    """Test prepare_execution calls pre_execute on all nodes."""
+    nodes = create_node_tree()
+    _root = nodes[0]
+    _root.prepare_execution()
+    for _node in nodes.values():
+        assert _node.plugin._pre_executed
 
-    def test_hash__simple(self):
-        obj = WorkflowNode(plugin=DummyLoader(), node_id=0)
-        self.assertIsInstance(hash(obj), int)
 
-    def test_hash__simple_comparison(self):
-        obj = WorkflowNode(plugin=DummyLoader(), node_id=0)
-        obj2 = WorkflowNode(plugin=DummyLoader(), node_id=0)
-        self.assertEqual(hash(obj), hash(obj2))
+def test_confirm_plugin_existence_and_type__no_plugin():
+    """Test that KeyError is raised when no plugin is provided."""
+    with pytest.raises(KeyError):
+        WorkflowNode()
 
-    def test_hash__complex_comparison(self):
-        _parent = WorkflowNode(plugin=DummyLoader(), node_id=0)
-        obj = WorkflowNode(plugin=DummyProc(), node_id=1, parent=_parent)
-        obj2 = WorkflowNode(plugin=DummyProc(), node_id=1, parent=_parent)
-        self.assertEqual(hash(obj), hash(obj2))
 
-    def test_hash__comparison_w_child(self):
-        _parent = WorkflowNode(plugin=DummyLoader(), node_id=0)
-        obj = WorkflowNode(plugin=DummyProc(), node_id=1, parent=_parent)
-        obj2 = WorkflowNode(plugin=DummyProc(), node_id=1, parent=_parent)
-        _ = WorkflowNode(plugin=DummyProc(), node_id=1, parent=obj)
-        self.assertNotEqual(hash(obj), hash(obj2))
+def test_confirm_plugin_existence_and_type__wrong_plugin():
+    """Test that TypeError is raised when plugin is not BasePlugin."""
+    with pytest.raises(TypeError):
+        WorkflowNode(plugin=12)
 
-    def test_hash__comparison_w_different_node_id(self):
-        _parent = WorkflowNode(plugin=DummyLoader(), node_id=0)
-        obj = WorkflowNode(plugin=DummyProc(), node_id=1, parent=_parent)
-        obj2 = WorkflowNode(plugin=DummyProc(), node_id=2, parent=_parent)
-        self.assertNotEqual(hash(obj), hash(obj2))
 
-    def test_hash__comparison_w_different_parent(self):
-        _parent = WorkflowNode(plugin=DummyLoader(), node_id=0)
-        _parent2 = WorkflowNode(plugin=DummyProc(), node_id=0)
-        obj = WorkflowNode(plugin=DummyProc(), node_id=1, parent=_parent)
-        obj2 = WorkflowNode(plugin=DummyProc(), node_id=1, parent=_parent2)
-        self.assertNotEqual(hash(obj), hash(obj2))
+def test_confirm_plugin_existence_and_type__correct_plugin():
+    """Test that correct plugin type is accepted."""
+    obj = WorkflowNode(plugin=DummyLoader())
+    assert isinstance(obj, WorkflowNode)
 
-    def test_hash__comparison_w_different_plugin(self):
-        _parent = WorkflowNode(plugin=DummyLoader(), node_id=0)
-        obj = WorkflowNode(plugin=DummyProc(), node_id=1, parent=_parent)
-        obj2 = WorkflowNode(plugin=DummyLoader(), node_id=2, parent=_parent)
-        self.assertNotEqual(hash(obj), hash(obj2))
 
-    def test_hash__comparison_w_different_plugin_param(self):
-        _parent = WorkflowNode(plugin=DummyLoader(), node_id=0)
-        obj = WorkflowNode(plugin=DummyProc(), node_id=1, parent=_parent)
-        obj.plugin.set_param_value("label", "Test")
-        obj2 = WorkflowNode(plugin=DummyProc(), node_id=2, parent=_parent)
-        self.assertNotEqual(hash(obj), hash(obj2))
+@pytest.mark.parametrize(
+    "ndim_parent_out,ndim_plugin_in,expected_check",
+    [
+        (-1, None, True),
+        (-1, 2, True),
+        (2, -1, True),
+        (2, 2, True),
+        (2, 1, False),
+    ],
+)
+def test_consistency_check(ndim_parent_out, ndim_plugin_in, expected_check):
+    """Test consistency_check with various dimension configurations."""
+    _root = WorkflowNode(plugin=DummyLoader())
+    assert _root.consistency_check() == True
+    _child = WorkflowNode(plugin=DummyProc(), parent=_root)
+    _root.plugin.base_output_data_dim = ndim_parent_out
+    _child.plugin.input_data_dim = ndim_plugin_in
+    assert _child.consistency_check() == expected_check
+
+
+def test_hash__returns_int():
+    """Test that hash returns an integer."""
+    obj = WorkflowNode(plugin=DummyLoader(), node_id=0)
+    assert isinstance(hash(obj), int)
+
+
+def test_hash__complex_comparison():
+    """Test hash equality with parent and same node_id."""
+    _parent = WorkflowNode(plugin=DummyLoader(), node_id=0)
+    _child1 = WorkflowNode(plugin=DummyProc(), node_id=1, parent=_parent)
+    _child2 = WorkflowNode(plugin=DummyProc(), node_id=1, parent=_parent)
+    assert hash(_child1) == hash(_child2)
+
+
+@pytest.mark.parametrize("plugin_class", [DummyLoader, DummyProc])
+@pytest.mark.parametrize("node_id", [2, 3])
+@pytest.mark.parametrize("parent", [0, 1])
+@pytest.mark.parametrize("label", ["", "Dummy"])
+@pytest.mark.parametrize("n_children", [0, 1])
+def test_hash_differs_on_config_change(
+    plugin_class, node_id, parent, label, n_children
+):
+    """Test that hash differs with various configuration changes."""
+    _parent = WorkflowNode(plugin=DummyLoader(), node_id=0)
+    _parent2 = WorkflowNode(plugin=DummyProc(), node_id=1)
+    _item1 = WorkflowNode(plugin=DummyProc(), node_id=2, parent=_parent)
+    _item2 = WorkflowNode(
+        plugin=plugin_class(),
+        node_id=node_id,
+        parent=_parent if parent == 0 else _parent2,
+    )
+    _item2.plugin.set_param_value("label", label)
+    if n_children == 1:
+        _child = WorkflowNode(plugin=DummyProc(), node_id=4, parent=_item2)
+
+    if (
+        plugin_class == DummyProc
+        and node_id == 2
+        and parent == 0
+        and label == ""
+        and n_children == 0
+    ):
+        assert hash(_item1) == hash(_item2)
+    else:
+        assert hash(_item1) != hash(_item2)
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main([__file__])

--- a/tests/workflow/test_workflow_node.py
+++ b/tests/workflow/test_workflow_node.py
@@ -331,5 +331,20 @@ def test_hash_differs_on_config_change(
         assert hash(_item1) != hash(_item2)
 
 
+# ---------------------
+# - Integration tests -
+# ---------------------
+def test_delete_note_references():
+    """Test delete_note_references with children."""
+    nodes = create_node_tree()
+    _root = nodes[0]
+    print("\nRoot children", _root.children)
+    _root.delete_node_references(recursive=True)
+    for _id, _node in nodes.items():
+        print(_id, _node.children)
+        assert _node.parent is None
+        assert _node.children == []
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/workflow/test_workflow_node.py
+++ b/tests/workflow/test_workflow_node.py
@@ -277,7 +277,7 @@ def test_confirm_plugin_existence_and_type__correct_plugin():
 def test_consistency_check(ndim_parent_out, ndim_plugin_in, expected_check):
     """Test consistency_check with various dimension configurations."""
     _root = WorkflowNode(plugin=DummyLoader())
-    assert _root.consistency_check() == True
+    assert _root.consistency_check()
     _child = WorkflowNode(plugin=DummyProc(), parent=_root)
     _root.plugin.base_output_data_dim = ndim_parent_out
     _child.plugin.input_data_dim = ndim_plugin_in

--- a/tests/workflow/test_workflow_node.py
+++ b/tests/workflow/test_workflow_node.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -18,22 +18,33 @@
 """Unit tests for pydidas modules."""
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
 
 
 import unittest
+from typing import Any
 
 import numpy as np
 
 from pydidas.contexts import DiffractionExperimentContext
+from pydidas.core import Dataset
 from pydidas.unittest_objects import DummyLoader, DummyProc
 from pydidas.workflow import WorkflowNode
 
 
 EXP = DiffractionExperimentContext()
+
+
+class _PluginModifyInPlace(DummyProc):
+    """Plugin to test modifying input data in place."""
+
+    def execute(self, data: Dataset, **kwargs: Any) -> tuple[Dataset, dict]:
+        data[0] = self.node_id
+        kwargs[self.node_id] = "::called::"
+        return data, kwargs
 
 
 class TestWorkflowNode(unittest.TestCase):
@@ -111,6 +122,28 @@ class TestWorkflowNode(unittest.TestCase):
         self.assertIsInstance(_dump, dict)
         for key in ("node_id", "parent", "children", "plugin_class", "plugin_params"):
             self.assertTrue(key in _dump.keys())
+
+    def test_execute_plugin_chain__w_plugin_modify_in_place(self):
+        root = WorkflowNode(node_id=0, plugin=DummyLoader())
+        child1 = WorkflowNode(node_id=1, plugin=_PluginModifyInPlace())
+        child2 = WorkflowNode(node_id=2, plugin=_PluginModifyInPlace())
+        child3 = WorkflowNode(node_id=3, plugin=DummyProc())
+        root.add_child(child1)
+        root.add_child(child2)
+        root.add_child(child3)
+        root.execute_plugin_chain(0, force_store_results=True, offset=3)
+        _root_data = root.results
+        _child1_data = child1.results
+        _child2_data = child2.results
+        _child3_data = child3.results
+        self.assertTrue(np.all(_root_data > 0))
+        self.assertTrue(np.allclose(_root_data + 3, _child3_data))
+        self.assertTrue(np.allclose(_child1_data[0], 1))
+        self.assertTrue(np.allclose(_child2_data[0], 2))
+        for _key, _node in [[1, child1], [2, child2], ["offset_03", child3]]:
+            self.assertEqual(
+                set(_node.result_kws), {_key, "offset", "index", "force_store_results"}
+            )
 
     def test_execute_plugin_chain(self):
         _depth = 3

--- a/tests/workflow/test_workflow_node.py
+++ b/tests/workflow/test_workflow_node.py
@@ -412,17 +412,48 @@ def test_clear_data__repeat_calls():
     assert obj.plugin._config["input_kwargs"] == {}
 
 
-# ---------------------
-# - Integration tests -
-# ---------------------
+# --------------------------------------------
+# - Integration tests of GenericNode methods -
+# --------------------------------------------
+
+
 def test_delete_note_references():
-    """Test delete_note_references with children."""
     nodes = create_node_tree()
     _root = nodes[0]
     _root.delete_node_references(recursive=True)
     for _id, _node in nodes.items():
         assert _node.parent is None
         assert _node.children == []
+
+
+def test_get_recursive_ids():
+    nodes = create_node_tree()
+    _root = nodes[0]
+    _ids = _root.get_recursive_ids()
+    assert set(_ids) == set(nodes)
+
+
+def test_connect_parent_to_children():
+    nodes = create_node_tree(depth=5, width=1)
+    assert nodes[1].parent == nodes[0]
+    assert nodes[2].parent == nodes[1]
+    assert nodes[0].children == [nodes[1]]
+    assert nodes[1].children == [nodes[2]]
+    nodes[1].connect_parent_to_children()
+    assert nodes[1].children == []
+    assert nodes[1].parent == None
+    assert nodes[0].children == [nodes[2]]
+    assert nodes[2].parent == nodes[0]
+
+
+def test_change_node_parent():
+    nodes = create_node_tree(depth=2, width=2)
+    assert nodes[3].parent == nodes[1]
+    assert nodes[3] in nodes[1].children
+    nodes[3].change_node_parent(nodes[2])
+    assert nodes[3].parent == nodes[2]
+    assert nodes[3] not in nodes[1].children
+    assert nodes[3] in nodes[2].children
 
 
 if __name__ == "__main__":

--- a/tests/workflow/test_workflow_node.py
+++ b/tests/workflow/test_workflow_node.py
@@ -412,9 +412,9 @@ def test_clear_data__repeat_calls():
     assert obj.plugin._config["input_kwargs"] == {}
 
 
-# --------------------------------------------
-# - Integration tests of GenericNode methods -
-# --------------------------------------------
+# -------------------------------------------
+# - Regression tests of GenericNode methods -
+# -------------------------------------------
 
 
 def test_delete_note_references():

--- a/tests/workflow/test_workflow_node.py
+++ b/tests/workflow/test_workflow_node.py
@@ -463,5 +463,6 @@ def test_reset_all_node_ids():
         assert _node.node_id is None
         assert _node.plugin.node_id is None
 
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Fixed a number of bugs, most important of which an issue which caused a memory leak in the WorkflowTestFrame:

- Fixed an issue in the SubtractBackgroundImage plugin which did not return
  the correct datatype when a threshold was set.
- Fixed a memory leak in the WorkflowTestFrame.
- Fixed an issue which increased memory consumption when switching between plots.
- Fixed an issue in the GenericNode which did not dereference children correctly
  in branching workflow trees.
- Fixed an issue in the WorkflowTestFrame where the results were kept in memory
  which used a higher peak memory.