### PR TITLE
Improve plot labels when displaying data structured in columns

### DIFF
--- a/src/pydidas/widgets/silx_plot/pydidas_plot1d.py
+++ b/src/pydidas/widgets/silx_plot/pydidas_plot1d.py
@@ -31,6 +31,7 @@ import warnings
 from typing import Any
 
 import numpy as np
+from matplotlib.ticker import AutoLocator, ScalarFormatter
 from qtpy import QtCore, QtWidgets
 from silx.gui.plot import Plot1D
 
@@ -205,7 +206,7 @@ class PydidasPlot1D(Plot1D):
             "resetzoom": False,
             "legend": kwargs.get("legend", "Curve"),
         } | get_allowed_kwargs(Plot1D.addCurve, kwargs)
-        self.setGraphXLabel(data.get_axis_description(_i_data) or "index")
+        self.set_axis_labels(1, _i_data, data)
         self.setGraphYLabel(kwargs.get("ylabel", _ylabel))
         if kwargs.get("title"):
             self.setGraphTitle(kwargs.get("title"))
@@ -230,6 +231,84 @@ class PydidasPlot1D(Plot1D):
         if _reset_zoom:
             self.resetZoom()
 
+    def set_axis_labels(self, label_axis: int, data_axis: int, data: Dataset) -> None:
+        """
+        Set the axis labels for the given axis.
+
+        Parameters
+        ----------
+        axis : int
+            The axis index to set the labels for.
+        data : Dataset
+            The dataset to get the labels from.
+        """
+        if self.axis_is_columns(data_axis, data):
+            labels = self.get_column_labels(data_axis, data)
+            backend = self.getBackend()
+            ax = backend.ax
+            if label_axis == 0:
+                ax.set_yticks(list(range(len(labels))), labels)
+            elif label_axis == 1:
+                ax.set_xticks(list(range(len(labels))), labels, rotation=90)
+            backend.fig.canvas.draw_idle()
+        else:
+            axis_desc = data.get_axis_description(data_axis)
+            if label_axis == 0:
+                self.setGraphYLabel(axis_desc)
+            elif label_axis == 1:
+                self.setGraphXLabel(axis_desc)
+
+    def axis_is_columns(self, axis: int, data: Dataset) -> bool:
+        """
+        Check if the given axis is structured in columns rather than continous
+        data. This is not a definitive check, it just looks at the axis labels.
+
+        Parameters
+        ----------
+        axis : int
+            The axis index to check.
+        data : Dataset
+            The dataset to check.
+
+        Returns
+        -------
+        bool
+            True if the axis is structured in columns rather than continous data
+        """
+        axis_label = data.get_axis_description(axis)
+        if ";" in axis_label:
+            column_labels = axis_label.split(";")
+            colon_in_label = True
+            for label in column_labels:
+                if ":" not in label:
+                    colon_in_label = False
+            return colon_in_label
+        return False
+
+    def get_column_labels(self, axis: int, data: Dataset) -> list[str]:
+        """
+        Get the column labels for the given axis. Assumes the axis is structured
+        in columns.
+
+        Parameters
+        ----------
+        axis : int
+            The axis index to get the column labels for.
+        data : Dataset
+            The dataset to get the column labels from.
+
+        Returns
+        -------
+        list[str]
+            The column labels for the given axis.
+        """
+        if self.axis_is_columns(axis, data):
+            return [
+                part.split(":", 1)[1].strip()
+                for part in data.get_axis_description(axis).split(";")
+            ]
+        raise ValueError(f"Axis {axis} does not contain columns.")
+
     # display_data is a generic alias used in all custom silx plots to have a
     # uniform interface call to display data in DataViewer-like classes
     display_data = plot_pydidas_dataset
@@ -243,6 +322,12 @@ class PydidasPlot1D(Plot1D):
         clear_data : bool, optional
             Flag to remove all items from the stored data dictionary as well.
         """
+        backend = self._backend
+        ax = backend.ax
+        ax.xaxis.set_major_locator(AutoLocator())
+        ax.xaxis.set_major_formatter(ScalarFormatter())
+        ax.yaxis.set_major_locator(AutoLocator())
+        ax.yaxis.set_major_formatter(ScalarFormatter())
         self.setGraphTitle("")
         self.setGraphYLabel("Y")
         self.setGraphXLabel("X")

--- a/src/pydidas/widgets/silx_plot/pydidas_plot1d.py
+++ b/src/pydidas/widgets/silx_plot/pydidas_plot1d.py
@@ -37,7 +37,11 @@ from silx.gui.plot import Plot1D
 
 from pydidas.core import Dataset, PydidasQsettings, UserConfigError
 from pydidas.widgets.silx_plot._special_plot_types_button import SpecialPlotTypesButton
-from pydidas.widgets.silx_plot.utilities import get_allowed_kwargs
+from pydidas.widgets.silx_plot.utilities import (
+    axis_is_columns,
+    get_allowed_kwargs,
+    get_column_labels,
+)
 
 
 _QSETTINGS = PydidasQsettings()
@@ -242,8 +246,8 @@ class PydidasPlot1D(Plot1D):
         data : Dataset
             The dataset to get the labels from.
         """
-        if self.axis_is_columns(data_axis, data):
-            labels = self.get_column_labels(data_axis, data)
+        if axis_is_columns(data_axis, data):
+            labels = get_column_labels(data_axis, data)
             backend = self.getBackend()
             ax = backend.ax
             if label_axis == 0:
@@ -257,57 +261,6 @@ class PydidasPlot1D(Plot1D):
                 self.setGraphYLabel(axis_desc)
             elif label_axis == 1:
                 self.setGraphXLabel(axis_desc)
-
-    def axis_is_columns(self, axis: int, data: Dataset) -> bool:
-        """
-        Check if the given axis is structured in columns rather than continous
-        data. This is not a definitive check, it just looks at the axis labels.
-
-        Parameters
-        ----------
-        axis : int
-            The axis index to check.
-        data : Dataset
-            The dataset to check.
-
-        Returns
-        -------
-        bool
-            True if the axis is structured in columns rather than continous data
-        """
-        axis_label = data.get_axis_description(axis)
-        if ";" in axis_label:
-            column_labels = axis_label.split(";")
-            colon_in_label = True
-            for label in column_labels:
-                if ":" not in label:
-                    colon_in_label = False
-            return colon_in_label
-        return False
-
-    def get_column_labels(self, axis: int, data: Dataset) -> list[str]:
-        """
-        Get the column labels for the given axis. Assumes the axis is structured
-        in columns.
-
-        Parameters
-        ----------
-        axis : int
-            The axis index to get the column labels for.
-        data : Dataset
-            The dataset to get the column labels from.
-
-        Returns
-        -------
-        list[str]
-            The column labels for the given axis.
-        """
-        if self.axis_is_columns(axis, data):
-            return [
-                part.split(":", 1)[1].strip()
-                for part in data.get_axis_description(axis).split(";")
-            ]
-        raise ValueError(f"Axis {axis} does not contain columns.")
 
     # display_data is a generic alias used in all custom silx plots to have a
     # uniform interface call to display data in DataViewer-like classes

--- a/src/pydidas/widgets/silx_plot/pydidas_plot1d.py
+++ b/src/pydidas/widgets/silx_plot/pydidas_plot1d.py
@@ -242,7 +242,7 @@ class PydidasPlot1D(Plot1D):
         Parameters
         ----------
         axis : int
-            The axis index to set the labels for.
+            The axis index to set the labels for. 0 for y-axis, 1 for x-axis.
         data : Dataset
             The dataset to get the labels from.
         """
@@ -275,7 +275,7 @@ class PydidasPlot1D(Plot1D):
         clear_data : bool, optional
             Flag to remove all items from the stored data dictionary as well.
         """
-        backend = self._backend
+        backend = self.getBackend()
         ax = backend.ax
         ax.xaxis.set_major_locator(AutoLocator())
         ax.xaxis.set_major_formatter(ScalarFormatter())

--- a/src/pydidas/widgets/silx_plot/pydidas_plot2d.py
+++ b/src/pydidas/widgets/silx_plot/pydidas_plot2d.py
@@ -56,7 +56,11 @@ from pydidas.widgets.silx_plot.silx_actions import (
     ExpandCanvas,
     PydidasGetDataInfoAction,
 )
-from pydidas.widgets.silx_plot.utilities import get_allowed_kwargs
+from pydidas.widgets.silx_plot.utilities import (
+    axis_is_columns,
+    get_allowed_kwargs,
+    get_column_labels,
+)
 from pydidas_qtcore import PydidasQApplication
 
 
@@ -475,8 +479,8 @@ class PydidasPlot2D(Plot2D, PydidasQsettingsMixin):
         data : Dataset
             The dataset to get the labels from.
         """
-        if self.axis_is_columns(axis, data):
-            labels = self.get_column_labels(axis, data)
+        if axis_is_columns(axis, data):
+            labels = get_column_labels(axis, data)
             backend = self.getBackend()
             ax = backend.ax
             if axis == 0:
@@ -490,57 +494,6 @@ class PydidasPlot2D(Plot2D, PydidasQsettingsMixin):
                 self.setGraphYLabel(axis_desc)
             elif axis == 1:
                 self.setGraphXLabel(axis_desc)
-
-    def axis_is_columns(self, axis: int, data: Dataset) -> bool:
-        """
-        Check if the given axis is structured in columns rather than continous
-        data. This is not a definitive check, it just looks at the axis labels.
-
-        Parameters
-        ----------
-        axis : int
-            The axis index to check.
-        data : Dataset
-            The dataset to check.
-
-        Returns
-        -------
-        bool
-            True if the axis is structured in columns rather than continous data
-        """
-        axis_label = data.get_axis_description(axis)
-        if ";" in axis_label:
-            column_labels = axis_label.split(";")
-            colon_in_label = True
-            for label in column_labels:
-                if ":" not in label:
-                    colon_in_label = False
-            return colon_in_label
-        return False
-
-    def get_column_labels(self, axis: int, data: Dataset) -> list[str]:
-        """
-        Get the column labels for the given axis. Assumes the axis is structured
-        in columns.
-
-        Parameters
-        ----------
-        axis : int
-            The axis index to get the column labels for.
-        data : Dataset
-            The dataset to get the column labels from.
-
-        Returns
-        -------
-        list[str]
-            The column labels for the given axis.
-        """
-        if self.axis_is_columns(axis, data):
-            return [
-                part.split(":", 1)[1].strip()
-                for part in data.get_axis_description(axis).split(";")
-            ]
-        raise ValueError(f"Axis {axis} does not contain columns.")
 
     # display_data is a generic alias used in all custom silx plots to have a
     # uniform interface call to display data in DataViewer-like classes

--- a/src/pydidas/widgets/silx_plot/pydidas_plot2d.py
+++ b/src/pydidas/widgets/silx_plot/pydidas_plot2d.py
@@ -33,6 +33,7 @@ from functools import partial
 from typing import Any
 
 import numpy as np
+from matplotlib.ticker import AutoLocator, ScalarFormatter
 from qtpy import QtCore
 from silx.gui.colors import Colormap
 from silx.gui.plot import Plot2D
@@ -416,6 +417,7 @@ class PydidasPlot2D(Plot2D, PydidasQsettingsMixin):
         **kwargs : Any
             Additional keyword arguments to be passed to the silx plot method.
         """
+        self.clear_plot()
         self._check_data_dim(data)
         _title = kwargs.pop("title", "")
         _plot_kwargs = {
@@ -442,15 +444,16 @@ class PydidasPlot2D(Plot2D, PydidasQsettingsMixin):
         self.update_cs_units(data.axis_units[1], data.axis_units[0])
         if _title:
             self.setGraphTitle(_title)
-        self.setGraphYLabel(data.get_axis_description(0))
-        self.setGraphXLabel(data.get_axis_description(1))
-        _cbar_legend = data.data_label
-        if data.data_unit:
-            if not _cbar_legend:
-                _cbar_legend += "unspecified"
-            _cbar_legend += f" / {data.data_unit}"
-        if _cbar_legend:
-            self.getColorBarWidget().setLegend(_cbar_legend)
+        self.set_axis_labels(0, data)
+        self.set_axis_labels(1, data)
+        if not self.axis_is_columns(0, data) and not self.axis_is_columns(1, data):
+            _cbar_legend = data.data_label
+            if data.data_unit:
+                if not _cbar_legend:
+                    _cbar_legend += "unspecified"
+                _cbar_legend += f" / {data.data_unit}"
+            if _cbar_legend:
+                self.getColorBarWidget().setLegend(_cbar_legend)
         if _data_has_same_shape:
             self.resetZoom()
         else:
@@ -460,6 +463,84 @@ class PydidasPlot2D(Plot2D, PydidasQsettingsMixin):
                 else self.expandCanvasAction
             )
             _action._actionTriggered()
+
+    def set_axis_labels(self, axis: int, data: Dataset) -> None:
+        """
+        Set the axis labels for the given axis.
+
+        Parameters
+        ----------
+        axis : int
+            The axis index to set the labels for.
+        data : Dataset
+            The dataset to get the labels from.
+        """
+        if self.axis_is_columns(axis, data):
+            labels = self.get_column_labels(axis, data)
+            backend = self.getBackend()
+            ax = backend.ax
+            if axis == 0:
+                ax.set_yticks(list(range(len(labels))), labels)
+            elif axis == 1:
+                ax.set_xticks(list(range(len(labels))), labels, rotation=90)
+            backend.fig.canvas.draw_idle()
+        else:
+            axis_desc = data.get_axis_description(axis)
+            if axis == 0:
+                self.setGraphYLabel(axis_desc)
+            elif axis == 1:
+                self.setGraphXLabel(axis_desc)
+
+    def axis_is_columns(self, axis: int, data: Dataset) -> bool:
+        """
+        Check if the given axis is structured in columns rather than continous
+        data. This is not a definitive check, it just looks at the axis labels.
+
+        Parameters
+        ----------
+        axis : int
+            The axis index to check.
+        data : Dataset
+            The dataset to check.
+
+        Returns
+        -------
+        bool
+            True if the axis is structured in columns rather than continous data
+        """
+        axis_label = data.get_axis_description(axis)
+        if ";" in axis_label:
+            column_labels = axis_label.split(";")
+            colon_in_label = True
+            for label in column_labels:
+                if ":" not in label:
+                    colon_in_label = False
+            return colon_in_label
+        return False
+
+    def get_column_labels(self, axis: int, data: Dataset) -> list[str]:
+        """
+        Get the column labels for the given axis. Assumes the axis is structured
+        in columns.
+
+        Parameters
+        ----------
+        axis : int
+            The axis index to get the column labels for.
+        data : Dataset
+            The dataset to get the column labels from.
+
+        Returns
+        -------
+        list[str]
+            The column labels for the given axis.
+        """
+        if self.axis_is_columns(axis, data):
+            return [
+                part.split(":", 1)[1].strip()
+                for part in data.get_axis_description(axis).split(";")
+            ]
+        raise ValueError(f"Axis {axis} does not contain columns.")
 
     # display_data is a generic alias used in all custom silx plots to have a
     # uniform interface call to display data in DataViewer-like classes
@@ -472,6 +553,12 @@ class PydidasPlot2D(Plot2D, PydidasQsettingsMixin):
 
     def clear_plot(self) -> None:
         """Clear the plot and remove all items."""
+        backend = self._backend
+        ax = backend.ax
+        ax.xaxis.set_major_locator(AutoLocator())
+        ax.xaxis.set_major_formatter(ScalarFormatter())
+        ax.yaxis.set_major_locator(AutoLocator())
+        ax.yaxis.set_major_formatter(ScalarFormatter())
         self.remove()
         self.setGraphTitle("")
         self.setGraphYLabel("")

--- a/src/pydidas/widgets/silx_plot/pydidas_plot2d.py
+++ b/src/pydidas/widgets/silx_plot/pydidas_plot2d.py
@@ -450,7 +450,7 @@ class PydidasPlot2D(Plot2D, PydidasQsettingsMixin):
             self.setGraphTitle(_title)
         self.set_axis_labels(0, data)
         self.set_axis_labels(1, data)
-        if not self.axis_is_columns(0, data) and not self.axis_is_columns(1, data):
+        if not axis_is_columns(0, data) and not axis_is_columns(1, data):
             _cbar_legend = data.data_label
             if data.data_unit:
                 if not _cbar_legend:
@@ -475,7 +475,7 @@ class PydidasPlot2D(Plot2D, PydidasQsettingsMixin):
         Parameters
         ----------
         axis : int
-            The axis index to set the labels for.
+            The axis index to set the labels for. 0 for y-axis, 1 for x-axis.
         data : Dataset
             The dataset to get the labels from.
         """
@@ -506,7 +506,7 @@ class PydidasPlot2D(Plot2D, PydidasQsettingsMixin):
 
     def clear_plot(self) -> None:
         """Clear the plot and remove all items."""
-        backend = self._backend
+        backend = self.getBackend()
         ax = backend.ax
         ax.xaxis.set_major_locator(AutoLocator())
         ax.xaxis.set_major_formatter(ScalarFormatter())

--- a/src/pydidas/widgets/silx_plot/utilities.py
+++ b/src/pydidas/widgets/silx_plot/utilities.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2025, Helmholtz-Zentrum Hereon
+# Copyright 2025 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -20,15 +20,17 @@ Module with utilities for silx_plot package files.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
-__all__ = ["get_allowed_kwargs"]
+__all__ = ["get_allowed_kwargs", "axis_is_columns", "get_column_labels"]
 
 
 import inspect
 from typing import Any, Callable
+
+from pydidas.core import Dataset
 
 
 _ALLOWED_KWARGS = {}
@@ -59,3 +61,58 @@ def get_allowed_kwargs(method: Callable, kwargs: dict[str, Any]) -> dict[str, An
         ]
     _whitelist = _ALLOWED_KWARGS[method]
     return {_key: _val for _key, _val in kwargs.items() if _key in _whitelist}
+
+
+def axis_is_columns(axis: int, data: Dataset) -> bool:
+    """
+    Check if the given axis is structured in columns rather than continous
+    data. This is not a definitive check, it just looks at the axis labels.
+
+    Parameters
+    ----------
+    axis : int
+        The axis index to check.
+    data : Dataset
+        The dataset to check.
+
+    Returns
+    -------
+    bool
+        True if the axis is structured in columns rather than continous data
+    """
+    axis_label = data.get_axis_description(axis)
+    if ";" in axis_label:
+        column_labels = axis_label.split(";")
+        if len(column_labels) != data.shape[axis]:
+            return False
+        colon_in_label = True
+        for label in column_labels:
+            if ":" not in label:
+                colon_in_label = False
+        return colon_in_label
+    return False
+
+
+def get_column_labels(axis: int, data: Dataset) -> list[str]:
+    """
+    Get the column labels for the given axis. Assumes the axis is structured
+    in columns.
+
+    Parameters
+    ----------
+    axis : int
+        The axis index to get the column labels for.
+    data : Dataset
+        The dataset to get the column labels from.
+
+    Returns
+    -------
+    list[str]
+        The column labels for the given axis.
+    """
+    if axis_is_columns(axis, data):
+        return [
+            part.split(":", 1)[1].strip()
+            for part in data.get_axis_description(axis).split(";")
+        ]
+    raise ValueError(f"Axis {axis} does not contain columns.")

--- a/src/pydidas/widgets/silx_plot/utilities.py
+++ b/src/pydidas/widgets/silx_plot/utilities.py
@@ -31,6 +31,7 @@ import inspect
 from typing import Any, Callable
 
 from pydidas.core import Dataset
+from pydidas_qtcore import PydidasQApplication
 
 
 _ALLOWED_KWARGS = {}
@@ -115,4 +116,7 @@ def get_column_labels(axis: int, data: Dataset) -> list[str]:
             part.split(":", 1)[1].strip()
             for part in data.get_axis_description(axis).split(";")
         ]
-    raise ValueError(f"Axis {axis} does not contain columns.")
+    PydidasQApplication.instance().set_status_message(
+        f"Warning: Axis {axis} does not contain columns. Labels may be incorrect."
+    )
+    return data.get_axis_description(axis).split(";")

--- a/tests/widgets/silx_plot/test_column_detection.py
+++ b/tests/widgets/silx_plot/test_column_detection.py
@@ -27,7 +27,7 @@ __status__ = "Production"
 import pytest
 
 from pydidas.unittest_objects import create_dataset
-from pydidas.widgets.silx_plot import PydidasPlot1D, PydidasPlot2D
+from pydidas.widgets.silx_plot.utilities import axis_is_columns, get_column_labels
 
 
 @pytest.fixture
@@ -37,12 +37,8 @@ def data():
 
 def test_axis_is_columns__continuous_data(data):
     data.axis_labels = {0: "axis1", 1: "axis2"}
-    plot1d = PydidasPlot1D()
-    assert not plot1d.axis_is_columns(0, data)
-    assert not plot1d.axis_is_columns(1, data)
-    plot2d = PydidasPlot2D()
-    assert not plot2d.axis_is_columns(0, data)
-    assert not plot2d.axis_is_columns(1, data)
+    assert not axis_is_columns(0, data)
+    assert not axis_is_columns(1, data)
 
 
 def test_axis_is_columns__columns(data):
@@ -50,23 +46,25 @@ def test_axis_is_columns__columns(data):
         0: "0: test0; 1: test1; 2: test2",
         1: "0: test0; 1: test1; 2: test2",
     }
-    plot1d = PydidasPlot1D()
-    assert plot1d.axis_is_columns(0, data)
-    assert plot1d.axis_is_columns(1, data)
-    plot2d = PydidasPlot2D()
-    assert plot2d.axis_is_columns(0, data)
-    assert plot2d.axis_is_columns(1, data)
+    assert axis_is_columns(0, data)
+    assert axis_is_columns(1, data)
+
+
+def test_axis_is_columns__malformed_columns(data):
+    data.axis_labels = {
+        0: "axis1; data: test",
+        1: "0: test0; 1: test1",
+    }
+    assert not axis_is_columns(0, data)
+    assert not axis_is_columns(1, data)
 
 
 def test_get_column_labels(data):
     data.axis_labels = {
         0: "0: test0; 1: test1; 2: test2",
-        1: "0: test0; 1: test1; 2: test2",
+        1: "test",
     }
     data.axis_units = {0: "", 1: ""}
-    plot1d = PydidasPlot1D()
-    assert plot1d.get_column_labels(0, data) == ["test0", "test1", "test2"]
-    assert plot1d.get_column_labels(1, data) == ["test0", "test1", "test2"]
-    plot2d = PydidasPlot2D()
-    assert plot2d.get_column_labels(0, data) == ["test0", "test1", "test2"]
-    assert plot2d.get_column_labels(1, data) == ["test0", "test1", "test2"]
+    assert get_column_labels(0, data) == ["test0", "test1", "test2"]
+    with pytest.raises(ValueError):
+        get_column_labels(1, data)

--- a/tests/widgets/silx_plot/test_column_detection.py
+++ b/tests/widgets/silx_plot/test_column_detection.py
@@ -1,0 +1,72 @@
+# This file is part of pydidas.
+#
+# Copyright 2025 - 2026, Helmholtz-Zentrum Hereon
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# pydidas is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# Pydidas is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for column detection in Plot1d and Plot2d widgets."""
+
+__author__ = "Nonni Heere"
+__copyright__ = "Copyright 2026, Helmholtz-Zentrum Hereon"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Malte Storm"
+__status__ = "Production"
+
+
+import pytest
+
+from pydidas.unittest_objects import create_dataset
+from pydidas.widgets.silx_plot import PydidasPlot1D, PydidasPlot2D
+
+
+@pytest.fixture
+def data():
+    return create_dataset(2, shape=(3, 3))
+
+
+def test_axis_is_columns__continuous_data(data):
+    data.axis_labels = {0: "axis1", 1: "axis2"}
+    plot1d = PydidasPlot1D()
+    assert not plot1d.axis_is_columns(0, data)
+    assert not plot1d.axis_is_columns(1, data)
+    plot2d = PydidasPlot2D()
+    assert not plot2d.axis_is_columns(0, data)
+    assert not plot2d.axis_is_columns(1, data)
+
+
+def test_axis_is_columns__columns(data):
+    data.axis_labels = {
+        0: "0: test0; 1: test1; 2: test2",
+        1: "0: test0; 1: test1; 2: test2",
+    }
+    plot1d = PydidasPlot1D()
+    assert plot1d.axis_is_columns(0, data)
+    assert plot1d.axis_is_columns(1, data)
+    plot2d = PydidasPlot2D()
+    assert plot2d.axis_is_columns(0, data)
+    assert plot2d.axis_is_columns(1, data)
+
+
+def test_get_column_labels(data):
+    data.axis_labels = {
+        0: "0: test0; 1: test1; 2: test2",
+        1: "0: test0; 1: test1; 2: test2",
+    }
+    data.axis_units = {0: "", 1: ""}
+    plot1d = PydidasPlot1D()
+    assert plot1d.get_column_labels(0, data) == ["test0", "test1", "test2"]
+    assert plot1d.get_column_labels(1, data) == ["test0", "test1", "test2"]
+    plot2d = PydidasPlot2D()
+    assert plot2d.get_column_labels(0, data) == ["test0", "test1", "test2"]
+    assert plot2d.get_column_labels(1, data) == ["test0", "test1", "test2"]

--- a/tests/widgets/silx_plot/test_column_detection.py
+++ b/tests/widgets/silx_plot/test_column_detection.py
@@ -62,9 +62,8 @@ def test_axis_is_columns__malformed_columns(data):
 def test_get_column_labels(data):
     data.axis_labels = {
         0: "0: test0; 1: test1; 2: test2",
-        1: "test",
+        1: "test3, test4",
     }
     data.axis_units = {0: "", 1: ""}
     assert get_column_labels(0, data) == ["test0", "test1", "test2"]
-    with pytest.raises(ValueError):
-        get_column_labels(1, data)
+    assert get_column_labels(1, data) == ["test3, test4"]


### PR DESCRIPTION
Plots try to detect column labels in axis descriptions and will display the column names instead of indeces. Resolves #145 