### PR TITLE
Fix column labels

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -105,6 +105,8 @@ Bugfixes
   edits
 - Fixed an issue in PydidasPlotStack which accepted ndarray without checks
   and crashed
+- Fixed an issue which occured if column labels in Datasets had the wrong number
+  of entries with respect to the data.
 
 
 v26.01.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -215,5 +215,5 @@ typing-extensions==4.15.0
     #   pydata-sphinx-theme
     #   pyopencl
     #   pytools
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests

--- a/src/pydidas/widgets/silx_plot/utilities.py
+++ b/src/pydidas/widgets/silx_plot/utilities.py
@@ -122,7 +122,7 @@ def get_column_labels(axis: int, data: Dataset) -> list[str]:
     PydidasQApplication.instance().set_status_message(
         f"Warning: Axis {axis} does not contain columns. Labels may be incorrect."
     )
-    return data.get_axis_description(axis).split(";")
+    return [f"column #{index}" for index in range(data.shape[axis])]
 
 
 def check_data_dimensions(data: Dataset | np.ndarray, target_dim: int) -> None:

--- a/tests/widgets/silx_plot/test_utilities.py
+++ b/tests/widgets/silx_plot/test_utilities.py
@@ -28,12 +28,39 @@ import numpy as np
 import pytest
 
 from pydidas.core import PydidasQsettings, UserConfigError
-from pydidas.unittest_objects import create_dataset
+from pydidas.unittest_objects import SignalSpy, create_dataset
 from pydidas.widgets.silx_plot.utilities import (
     axis_is_columns,
     check_data_dimensions,
     get_column_labels,
 )
+
+
+_MALFORMED_LABELS = [
+    # Missing separators / punctuation
+    "0 item_A; 1: item_B; 2: item_C",
+    "0: item_A 1: item_B; 2: item_C",
+    "0: item_A; 1 item_B; 2: item_C",
+    "0 item_A; 1: item_B 2: item_C",
+    # Missing semicolons
+    "0: item_A 1: item_B 2: item_C",
+    "0: item_A; 1: item_B; 2 item_C",
+    # Missing fields
+    "0: item_A; 1: item_B",
+    "0: item_A; 3: item_D",
+    "1: item_B; 2: item_C",
+    # Extra tokens
+    "0: item_A; 1: item_B; 2: item_C; extra",
+    "0: item_A; 1: item_B; something; 2: item_C; 3: item_D",
+    "0: item_A; 1: item_B; 2: item_C; 3: unknown",
+]
+_FORMATTED_LABELS = [
+    "0: test0; 1: test1; 2: test2",
+    "0: test0; 1: test1: A; 2: test1: B",
+    "0: test0 / unitA; 1: test1; 2: test2 / unitC",
+    "0: test0 / unitA; 1: test1 / unitA; 2: test2 / unitA",
+    "0: test0 / unitC; 1: test0 / unitA; 2: test2 / unitA",
+]
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -48,7 +75,9 @@ def set_max_number_curves_to_five():
 
 @pytest.fixture
 def data():
-    return create_dataset(2, shape=(3, 3))
+    _data = create_dataset(2, shape=(3, 3))
+    _data.axis_units = {0: "", 1: ""}
+    return _data
 
 
 @pytest.mark.parametrize("target_dim", [1, 2, 3])
@@ -87,34 +116,36 @@ def test_axis_is_columns__continuous_data(data):
     assert not axis_is_columns(1, data)
 
 
-def test_axis_is_columns__columns(data):
-    data.axis_labels = {
-        0: "0: test0; 1: test1; 2: test2",
-        1: "0: test0; 1: test1; 2: test2",
-    }
+@pytest.mark.parametrize("label", _FORMATTED_LABELS)
+def test_axis_is_columns__w_columns(data, label):
+    data.update_axis_label(0, label)
     assert axis_is_columns(0, data)
-    assert axis_is_columns(1, data)
 
 
-def test_axis_is_columns__malformed_columns(data):
-    data.axis_labels = {
-        0: "axis1; data: test",
-        1: "0: test0; 1: test1",
-    }
+@pytest.mark.parametrize("label", _MALFORMED_LABELS)
+def test_axis_is_columns__malformed_columns(data, label):
+    data.update_axis_label(0, label)
     assert not axis_is_columns(0, data)
-    assert not axis_is_columns(1, data)
 
 
-def test_get_column_labels(data):
-    data.axis_labels = {
-        0: "0: test0; 1: test1; 2: test2",
-        1: "test3, test4",
-    }
-    data.axis_units = {0: "", 1: ""}
-    assert get_column_labels(0, data) == ["test0", "test1", "test2"]
-    assert get_column_labels(1, data) == ["test3, test4"]
+@pytest.mark.parametrize("label", _FORMATTED_LABELS)
+def test_get_column_labels(data, label):
+    _expectation = [_l.split(":", 1)[1].strip() for _l in label.split(";")]
+    data.update_axis_label(0, label)
+    data.update_axis_unit(0, "")
+    assert get_column_labels(0, data) == _expectation
+
+
+@pytest.mark.parametrize("label", _MALFORMED_LABELS)
+def test_get_column_labels__wrong_formats(qapp, data, label):
+    _spy = SignalSpy(qapp.sig_status_message)
+    data.update_axis_label(0, label)
+    assert _spy.n == 0
+    _labels = get_column_labels(0, data)
+    assert _spy.n == 1
+    assert len(_labels) == data.shape[0]
+    assert _labels == [f"column #{index}" for index in range(data.shape[1])]
 
 
 if __name__ == "__main__":
     pytest.main([__file__])
-#


### PR DESCRIPTION
Fixed an issue which occured if column labels in Datasets had the wrong number of entries with respect to the data.