### PR TITLE
Fix workflow test frame

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,8 @@ Bugfixes
 --------
 - Fixed an issue in the DataBrowsingFrame which did not load the icons for 
   the starting directory correctly.
-
+- Fixed an issue in the WorkflowTestFrame which de-selected the node after
+  running the test for a different datapoint.
 
 v26.05.19
 =========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Bugfixes
   the starting directory correctly.
 - Fixed an issue in the WorkflowTestFrame which de-selected the node after
   running the test for a different datapoint.
+- Fixed an issue which would not scale 1d plots correctly due to Qt's 
+  processing queue for signals and its use in PydidasPlot1d.
 
 v26.05.19
 =========

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ hdf5plugin==6.0.0
     # via
     #   -r requirements.in
     #   fabio
-idna==3.11
+idna==3.16
     # via requests
 imagecodecs==2026.3.6
     # via -r requirements.in

--- a/src/pydidas/gui/frames/builders/workflow_test_frame_builder.py
+++ b/src/pydidas/gui/frames/builders/workflow_test_frame_builder.py
@@ -26,6 +26,7 @@ __maintainer__ = "Malte Storm"
 __status__ = "Production"
 __all__ = ["get_WorkflowTestFrame_build_config"]
 
+from typing import Any
 
 from qtpy import QtCore
 
@@ -66,7 +67,7 @@ def __param_widget_config(param_key: str) -> dict:
 
 def get_WorkflowTestFrame_build_config(
     frame: BaseFrame,
-) -> list[list[str, tuple[str], dict]]:
+) -> list[list[str | tuple[str] | dict[str, Any]]]:
     """
     Return the build configuration for the WorkflowTestFrame.
 

--- a/src/pydidas/gui/frames/workflow_test_frame.py
+++ b/src/pydidas/gui/frames/workflow_test_frame.py
@@ -176,7 +176,7 @@ class WorkflowTestFrame(BaseFrame):
         """
         BaseFrame.__init__(self, **kwargs)
         self.set_default_params()
-        self._tree = None
+        self._tree: WorkflowTree | None = None
         self._active_node = -1
         self._results = {}
         self._config.update(
@@ -302,6 +302,8 @@ class WorkflowTestFrame(BaseFrame):
         if not self._check_tree_is_populated():
             return
         with utils.ShowBusyMouse():
+            _selected_row = self._widgets["result_table"].selected_row_id
+            _selected_label = self._widgets["result_table"].selected_node_label
             self.clear_results()
             _index = self.__get_index()
             self._tree.execute_process(
@@ -312,8 +314,11 @@ class WorkflowTestFrame(BaseFrame):
                 test=True,
             )
             self.__store_tree_results()
-            self.__update_selection_choices()
+            self.__update_selection_choices(
+                selected_row=_selected_row, selected_label=_selected_label
+            )
             if self._active_node != -1:
+                self.__set_derived_widget_visibility(True)
                 self.__update_text_description_of_node_results()
                 self.__plot_results()
 
@@ -450,9 +455,27 @@ class WorkflowTestFrame(BaseFrame):
         if self._active_node not in self._results:
             self._active_node = -1
 
-    def __update_selection_choices(self) -> None:
-        """Update the choice of results to display"""
-        self._widgets["result_table"].update_node_descriptions(self._result_titles)
+    def __update_selection_choices(
+        self, selected_row: int = -1, selected_label: str = ""
+    ) -> None:
+        """
+        Update the choice of results to display
+
+        If an entry with a selected row and selected label is given, it will
+        be restored if the new entries match the old one.
+
+        Parameters
+        ----------
+        selected_row : int
+            The previously selected row.
+        selected_label : str
+            The selected label.
+        """
+        _table = self._widgets["result_table"]
+        _table.update_node_descriptions(self._result_titles)
+        if _table.get_row_label(selected_row) == selected_label:
+            with QtCore.QSignalBlocker(_table):
+                _table.setCurrentCell(selected_row, 0)
 
     @QtCore.Slot(int)
     def _selected_new_node(self, index: int) -> None:

--- a/src/pydidas/gui/frames/workflow_test_frame.py
+++ b/src/pydidas/gui/frames/workflow_test_frame.py
@@ -473,7 +473,7 @@ class WorkflowTestFrame(BaseFrame):
         """
         _table = self._widgets["result_table"]
         _table.update_node_descriptions(self._result_titles)
-        if _table.get_row_label(selected_row) == selected_label:
+        if selected_row >= 0 and _table.get_row_label(selected_row) == selected_label:
             with QtCore.QSignalBlocker(_table):
                 _table.setCurrentCell(selected_row, 0)
 

--- a/src/pydidas/widgets/data_viewer/table_with_node_labels.py
+++ b/src/pydidas/widgets/data_viewer/table_with_node_labels.py
@@ -50,8 +50,22 @@ class TableWithNodeLabels(PydidasQTable):
         kwargs["font_metric_height_factor"] = kwargs.get("font_metric_height_factor", 6)
         PydidasQTable.__init__(self, **kwargs)
         apply_qt_properties(self, columnCount=1, rowCount=0)
-        self._row_items = {}
+        self._row_node_ids: dict[int, int] = {}
+        self._row_labels: dict[int, str] = {}
         self.selectionModel().selectionChanged.connect(self.emit_new_node_selection)
+
+    @property
+    def selected_node_label(self) -> str:
+        """
+        Get the label of the currently selected node.
+
+        Returns
+        -------
+        str
+            The label of the currently selected node.
+        """
+        _label = self._row_labels.get(self.selected_row_id)
+        return _label or ""
 
     @QtCore.Slot()
     def emit_new_node_selection(self) -> None:
@@ -59,7 +73,23 @@ class TableWithNodeLabels(PydidasQTable):
         Emit the signal of a new selection.
         """
         if self.selected_row_id >= 0:
-            self.sig_node_selected.emit(self._row_items[self.selected_row_id])
+            self.sig_node_selected.emit(self._row_node_ids[self.selected_row_id])
+
+    def get_row_label(self, row_id: int) -> str:
+        """
+        Get the label of a given row.
+
+        Parameters
+        ----------
+        row_id: int
+            The id of the row for which to get the label.
+
+        Returns
+        -------
+        str
+            The label of the given row.
+        """
+        return self._row_labels.get(row_id, "")
 
     def update_node_descriptions(self, titles: dict[int, str]) -> None:
         """
@@ -71,9 +101,12 @@ class TableWithNodeLabels(PydidasQTable):
             The dictionary with node ids and their corresponding labels.
         """
         self.remove_all_rows()
-        self._row_items = {_i: _node_id for _i, _node_id in enumerate(titles)}
+        self._row_node_ids = {}
+        self._row_labels = {}
         self.setRowCount(len(titles))
         for _i_row, (_node_id, _label) in enumerate(titles.items()):
+            self._row_node_ids[_i_row] = _node_id
+            self._row_labels[_i_row] = _label
             self.setItem(_i_row, 0, QtWidgets.QTableWidgetItem(_label))
         self.setVisible(True)
         self.setFixedHeight(self.table_display_height)

--- a/src/pydidas/widgets/factory/pydidas_table.py
+++ b/src/pydidas/widgets/factory/pydidas_table.py
@@ -61,11 +61,9 @@ class PydidasQTable(PydidasWidgetMixin, QtWidgets.QTableWidget):
         self._rel_column_widths = kwargs.pop("relative_column_widths", None)
         self._autoscale_height = kwargs.pop("autoscale_height", False)
         self._qtapp = PydidasQApplication.instance()
-        QtWidgets.QTableWidget.__init__(
-            self,
-            rowCount=kwargs.pop("rowCount", 0),
-            columnCount=kwargs.pop("columnCount", 0),
-        )
+        QtWidgets.QTableWidget.__init__(self)
+        self.setRowCount(kwargs.pop("rowCount", 0))
+        self.setColumnCount(kwargs.pop("columnCount", 0))
         PydidasWidgetMixin.__init__(self, **kwargs)
         self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
         self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)

--- a/src/pydidas/widgets/factory/pydidas_table.py
+++ b/src/pydidas/widgets/factory/pydidas_table.py
@@ -49,7 +49,7 @@ class PydidasQTable(PydidasWidgetMixin, QtWidgets.QTableWidget):
         "relative_column_widths",
         "autoscale_height",
         # need to handle the Qt properties for columnCount and rowCount here to
-        # handle the relative column widths correctly
+        # handle the relative column widths correctly:
         "columnCount",
         "rowCount",
     ]
@@ -62,7 +62,9 @@ class PydidasQTable(PydidasWidgetMixin, QtWidgets.QTableWidget):
         self._autoscale_height = kwargs.pop("autoscale_height", False)
         self._qtapp = PydidasQApplication.instance()
         QtWidgets.QTableWidget.__init__(
-            self, kwargs.pop("rowCount", 0), kwargs.pop("columnCount", 0)
+            self,
+            rowCount=kwargs.pop("rowCount", 0),
+            columnCount=kwargs.pop("columnCount", 0),
         )
         PydidasWidgetMixin.__init__(self, **kwargs)
         self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
@@ -218,7 +220,7 @@ class PydidasQTable(PydidasWidgetMixin, QtWidgets.QTableWidget):
         self._set_new_height()
 
     def add_multicolumn_cell(
-        self, label: str, start_col: int = 0, n_col: int | None = None
+        self, label: str, start_col: int = 0, n_col: int = -1
     ) -> None:
         """
         Add a cell which spans all columns in the table.
@@ -229,15 +231,15 @@ class PydidasQTable(PydidasWidgetMixin, QtWidgets.QTableWidget):
             The label of the spanned row.
         start_col : int, optional
             The column index at which the spanned cell starts, by default 0.
-        n_col : int or None, optional
-            The number of columns to span, by default None which spans all
+        n_col : int, optional
+            The number of columns to span, by default -1 which spans all
             columns.
         """
         self._wrapped_cells = True
         self.setVisible(True)
         _i_row = self.rowCount()
         self.setRowCount(_i_row + 1)
-        if n_col is None:
+        if n_col == -1:
             n_col = self.columnCount() - start_col
         _item = QtWidgets.QTableWidgetItem(label)
         self.setItem(_i_row, start_col, _item)

--- a/src/pydidas/widgets/silx_plot/pydidas_plot1d.py
+++ b/src/pydidas/widgets/silx_plot/pydidas_plot1d.py
@@ -199,7 +199,7 @@ class PydidasPlot1D(Plot1D):
                 )
             self.setActiveCurve(_label.format(value=data.axis_ranges[0][0]))
         if _reset_zoom and not self._lock_zoom_action.locked:
-            self.resetZoom()
+            QtCore.QTimer.singleShot(0, self.resetZoom)
 
     # display_data is a generic alias used in all custom silx plots to have a
     # uniform interface call to display data in DataViewer-like classes

--- a/src/pydidas/widgets/silx_plot/utilities.py
+++ b/src/pydidas/widgets/silx_plot/utilities.py
@@ -24,7 +24,12 @@ __copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
-__all__ = ["get_allowed_kwargs"]
+__all__ = [
+    "get_allowed_kwargs",
+    "axis_is_columns",
+    "get_column_labels",
+    "check_data_dimensions",
+]
 
 
 import inspect
@@ -82,7 +87,7 @@ def axis_is_columns(axis: int, data: Dataset) -> bool:
     Returns
     -------
     bool
-        True if the axis is structured in columns rather than continous data
+        True if the axis is structured in columns rather than continuous data
     """
     axis_label = data.get_axis_description(axis)
     if ";" in axis_label:
@@ -133,6 +138,8 @@ def check_data_dimensions(data: Dataset | np.ndarray, target_dim: int) -> None:
     ----------
     data : Dataset or np.ndarray
         The data to display.
+    target_dim : int
+        The expected data dimension.
     """
     if data.ndim == target_dim:
         return


### PR DESCRIPTION
- Updated a pinned dependency for a security fix
- Fixed an issue in the WorkflowTestFrame which de-selected the node after
  running the test for a different datapoint.
- Fixed an issue which would not scale 1d plots correctly due to Qt's 
  processing queue for signals and its use in PydidasPlot1d.