### PR TITLE
Fix import squeeze

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Bugfixes
 --------
 - Fixed an issue in the DataBrowsingFrame which did not load the icons for 
   the starting directory correctly.
+- Fixed an issue with importing data with scan dimensions of size 1 which 
+  were squeezed during export.
 
 
 v26.05.19

--- a/src/pydidas/contexts/scan/scan.py
+++ b/src/pydidas/contexts/scan/scan.py
@@ -29,7 +29,7 @@ __all__ = ["Scan"]
 
 import warnings
 from pathlib import Path
-from typing import Any, Literal, Union
+from typing import Any
 
 import numpy as np
 
@@ -90,7 +90,7 @@ class Scan(ObjectWithParameterCollection):
 
     default_params = SCAN_DEFAULT_PARAMS
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.set_default_params()
         self._scan_io = None
@@ -149,7 +149,7 @@ class Scan(ObjectWithParameterCollection):
             0 <= _index <= _shapes[_dim]  # noqa
             for _dim, _index in enumerate(indices)
         ]
-        if False in _indices_okay:
+        if not all(_indices_okay):
             raise UserConfigError(
                 f"The given indices {tuple(indices)} are out of the scope "
                 f"of the scan range {self.shape}"
@@ -158,9 +158,7 @@ class Scan(ObjectWithParameterCollection):
         _index = np.sum(_factors * indices)
         return _index
 
-    def get_metadata_for_dim(
-        self, index: Literal[0, 1, 2, 3]
-    ) -> tuple[str, str, np.ndarray]:
+    def get_metadata_for_dim(self, index: int) -> tuple[str, str, np.ndarray]:
         """
         Get the label, unit and range of the specified scan dimension.
 
@@ -169,8 +167,8 @@ class Scan(ObjectWithParameterCollection):
 
         Parameters
         ----------
-        index : Literal[0, 1, 2, 3]
-            The index of the scan dimension.
+        index : int
+            The index of the scan dimension (only 0, 1, 2, 3 are supported).
 
         Returns
         -------
@@ -192,13 +190,13 @@ class Scan(ObjectWithParameterCollection):
         """
         Get the Scan range for the specified dimension.
 
-        Note: The scan dimensions are 0 ... 3 and follow the python convention of
-        starting with zero.
+        Note: The scan dimensions are 0 ... 3 and follow the python
+        convention of starting with zero.
 
         Parameters
         ----------
-        index : Union[0, 1, 2, 3]
-            The scan dimension
+        index : int
+            The scan dimension (only 0, 1, 2, 3 are supported).
 
         Returns
         -------
@@ -212,22 +210,22 @@ class Scan(ObjectWithParameterCollection):
         _n = self.get_param_value(f"scan_dim{index}_n_points")
         return np.linspace(_f0, _f0 + _df * _n, _n, endpoint=False)  # noqa
 
-    def update_from_scan(self, scan: "Scan"):
+    def update_from_scan(self, scan: "Scan") -> None:
         """
         Update this Scan object's Parameters from another Scan.
 
-        The purpose of this method is to "copy" the other Scan's Parameter values while
-        keeping the reference to this object.
+        The purpose of this method is to copy the other Scan's
+        Parameter values while keeping the reference to this object.
 
         Parameters
         ----------
         scan : Scan
             The other Scan from which the Parameters should be taken.
         """
-        for _key, _val in scan.get_param_values_as_dict().items():
-            self.set_param_value(_key, _val)
+        for _key, _param in scan.params.items():
+            self.set_param_value(_key, _param.value)
 
-    def update_from_dictionary(self, scan_dict: dict):
+    def update_from_dictionary(self, scan_dict: dict) -> None:
         """
         Update the Scan from an imported dictionary.
 
@@ -236,9 +234,9 @@ class Scan(ObjectWithParameterCollection):
         scan_dict : dict
             The dictionary with the data to import.
         """
-        if scan_dict == {}:
+        if not scan_dict:
             return
-        for _pname in [
+        for _param_name in [
             "scan_dim",
             "scan_title",
             "scan_base_directory",
@@ -248,7 +246,7 @@ class Scan(ObjectWithParameterCollection):
             "scan_frames_per_point",
             "scan_multi_frame_handling",
         ]:
-            self.set_param_value(_pname, scan_dict[_pname])
+            self.set_param_value(_param_name, scan_dict[_param_name])
         for _dim in range(self.get_param_value("scan_dim")):
             _curr_dim_info = scan_dict[_dim]
             for _entry in ["label", "unit", "offset", "delta", "n_points"]:
@@ -267,6 +265,22 @@ class Scan(ObjectWithParameterCollection):
         return tuple(
             self.get_param_value(f"scan_dim{_i}_n_points")
             for _i in range(self.ndim)  # noqa
+        )
+
+    @property
+    def squeezed_shape(self) -> tuple[int, ...]:
+        """
+        Get the shape of the Scan with all dimensions of length 1 removed.
+
+        Returns
+        -------
+        tuple[int]
+            The tuple with an entry of the length for each dimension.
+        """
+        return tuple(
+            self.get_param_value(f"scan_dim{_i}_n_points")
+            for _i in range(self.ndim)  # noqa
+            if self.get_param_value(f"scan_dim{_i}_n_points") > 1
         )
 
     @property
@@ -369,13 +383,13 @@ class Scan(ObjectWithParameterCollection):
             "#" * _len_pattern, "{index:0" + str(_len_pattern) + "d}"
         )
 
-    def import_from_file(self, filename: Union[str, Path]):
+    def import_from_file(self, filename: str | Path) -> None:
         """
         Import ScanContext from a file.
 
         Parameters
         ----------
-        filename : Union[str, pathlib.Path]
+        filename : str or Path
             The full filename.
         """
         if self._scan_io is None:
@@ -384,17 +398,17 @@ class Scan(ObjectWithParameterCollection):
             self._scan_io = ScanIo
         self._scan_io.import_from_file(filename, scan=self)
 
-    def export_to_file(self, filename: Union[str, Path], overwrite: bool = False):
+    def export_to_file(self, filename: str | Path, overwrite: bool = False) -> None:
         """
         Export ScanContext to a file.
 
         Parameters
         ----------
-        filename : Union[str, pathlib.Path]
+        filename : str or Path
             The full filename.
         overwrite : bool
-            Keyword to allow overwriting of existing files. The default is
-            False.
+            Keyword to allow overwriting of existing files.
+            The default is False.
         """
         if self._scan_io is None:
             from pydidas.contexts.scan.scan_io import ScanIo
@@ -402,7 +416,7 @@ class Scan(ObjectWithParameterCollection):
             self._scan_io = ScanIo
         self._scan_io.export_to_file(filename, scan=self, overwrite=overwrite)
 
-    def set_param_value(self, param_key: str, value: Any):
+    def set_param_value(self, param_key: str, value: Any) -> None:
         """
         Set the value of a parameter.
 

--- a/src/pydidas/contexts/scan/scan_io.py
+++ b/src/pydidas/contexts/scan/scan_io.py
@@ -95,7 +95,7 @@ class ScanIo(GenericIoMeta):
         cls.beamline_format_registry = {}
 
     @classmethod
-    def import_from_file(cls, filename: str, scan: Scan | None = None):
+    def import_from_file(cls, filename: Path | str, scan: Scan | None = None):
         """
         Import a Scan from file and update the given Scan object.
 
@@ -104,7 +104,7 @@ class ScanIo(GenericIoMeta):
 
         Parameters
         ----------
-        filename : str
+        filename : Path or str
             The full filename and path.
         scan : Scan, optional
             The Scan object to be updated. If None, the generic ScanContext is used.

--- a/src/pydidas/core/io_registry/generic_io_base.py
+++ b/src/pydidas/core/io_registry/generic_io_base.py
@@ -44,7 +44,7 @@ class GenericIoBase(metaclass=GenericIoMeta):
     imported_params = {}
 
     @classmethod
-    def export_to_file(cls, filename, *args: Any, **kwargs: Any) -> None:
+    def export_to_file(cls, filename: Path | str, *args: Any, **kwargs: Any) -> None:
         """
         Write the content to a file.
 
@@ -52,7 +52,7 @@ class GenericIoBase(metaclass=GenericIoMeta):
 
         Parameters
         ----------
-        filename : str
+        filename : Path or str
             The filename of the file to be written.
         **kwargs : Any
             Any keyword arguments. Supported keywords must be specified by

--- a/src/pydidas/core/parameter_collection.py
+++ b/src/pydidas/core/parameter_collection.py
@@ -30,8 +30,8 @@ __status__ = "Production"
 __all__ = ["ParameterCollection"]
 
 
-from collections.abc import Iterable
-from typing import Any, Self
+from collections.abc import Collection
+from typing import Any, NoReturn
 
 from pydidas.core.parameter import Parameter
 from pydidas.core.utils.iterable_utils import flatten
@@ -50,17 +50,15 @@ class ParameterCollection(dict):
 
     Parameters
     ----------
-    *args : Union[Parameter, ParameterCollection]
+    *args : Parameter or ParameterCollection
         Any number of Parameter or ParameterCollection instances
-    **kwargs : dict
-        Any number of Parameters
     """
 
-    def __init__(self, *args: Parameter | Self):
+    def __init__(self, *args: "Parameter | ParameterCollection") -> None:
         super().__init__()
-        self.add_params(*args)
+        self.add_params(*args)  # type: ignore[arg-type]
 
-    def __copy__(self) -> Self:
+    def __copy__(self) -> "ParameterCollection":
         """
         Get a copy of the ParameterCollection.
 
@@ -79,7 +77,7 @@ class ParameterCollection(dict):
             _copy.add_param(_new_param)
         return _copy
 
-    def __hash__(self) -> int:
+    def __hash__(self) -> int:  # type: ignore[override]
         """
         Create a hash value for the ParameterCollection.
 
@@ -95,7 +93,7 @@ class ParameterCollection(dict):
         _values = tuple(hash(_val) for _val in self.values())
         return hash((_keys, _values))
 
-    def __setitem__(self, key: str, param: Parameter):
+    def __setitem__(self, key: str, param: Parameter) -> None:
         """
         Assign a value to a dictionary key.
 
@@ -127,15 +125,31 @@ class ParameterCollection(dict):
         self.__check_key_available(param)
         super().__setitem__(key, param)
 
+    def __getitem__(self, key: str) -> Parameter:
+        """
+        Get the requested Parameter
+
+        Parameters
+        ----------
+        key : str
+            The reference key.
+
+        Returns
+        -------
+        Parameter
+            The requested Parameter.
+        """
+        return super().__getitem__(key)
+
     @staticmethod
-    def __raise_type_error(item: object):
+    def __raise_type_error(item: Any) -> NoReturn:
         """
         Raise a TypeError that item is of the wrong type.
 
         Parameters
         ----------
-        item : object
-            Any item.
+        item : Any
+            Any item (which cannot be added to the ParameterCollection).
 
         Raises
         ------
@@ -148,8 +162,8 @@ class ParameterCollection(dict):
         )
 
     def __check_key_available(
-        self, param: Parameter, keys: Iterable[str] | None = None
-    ):
+        self, param: Parameter, keys: Collection[str] | None = None
+    ) -> None | NoReturn:
         """
         Check if the Parameter refkey is already a registered key.
 
@@ -157,7 +171,7 @@ class ParameterCollection(dict):
         ----------
         param : Parameter
             The Parameter to be compared.
-        keys : Iterable[str] | None, optional
+        keys : Collection[str] or None, optional
             The keys to be compared against. If None, the comparison will be
             performed against all dictionary keys. The default is None.
 
@@ -173,7 +187,7 @@ class ParameterCollection(dict):
                 f"A parameter with the reference key '{param.refkey}' already exists."
             )
 
-    def add_param(self, param: Parameter):
+    def add_param(self, param: Parameter) -> None:
         """
         Add a parameter to the ParameterCollection.
 
@@ -195,7 +209,7 @@ class ParameterCollection(dict):
         self.__check_key_available(param)
         self.__setitem__(param.refkey, param)
 
-    def __check_arg_types(self, *args: Parameter | Self):
+    def __check_arg_types(self, *args: Any) -> None:
         """
         Check the types of input arguments.
 
@@ -204,7 +218,7 @@ class ParameterCollection(dict):
 
         Parameters
         ----------
-        *args : Parameter | Self
+        *args : Any
             Any arguments.
         """
         for _param in args:
@@ -223,25 +237,25 @@ class ParameterCollection(dict):
         """
         return list(self.keys())
 
-    def add_params(self, *args: tuple[Parameter, Self, dict]):
+    def add_params(self, *args: "Parameter | ParameterCollection") -> None:
         """
         Add parameters to the ParameterCollection.
 
         This method adds Parameters to the ParameterCollection.
         Parameters can be either supplied individually as arguments or as
-        ParameterCollections or dictionaries.
+        ParameterCollections.
 
         Parameters
         ----------
-        *args : tuple[Parameter, dict, ParameterCollection]
-            Any dict, Parameter or ParameterCollection
+        *args : Parameter or ParameterCollection
+            Any Parameter or ParameterCollection
         """
         # perform all type checks before adding any items:
-        self.__check_arg_types(*args)
-        self.__check_duplicate_keys(*args)
-        self.__add_arg_params(*args)
+        self.__check_arg_types(*args)  # type: ignore[arg-type]
+        self.__check_duplicate_keys(*args)  # type: ignore[arg-type]
+        self.__add_arg_params(*args)  # type: ignore[arg-type]
 
-    def __check_duplicate_keys(self, *args: dict[str, Parameter] | Parameter | Self):
+    def __check_duplicate_keys(self, *args: "Parameter | ParameterCollection") -> None:
         """
         Check for duplicate keys and raise an error if a duplicate key is found.
 
@@ -250,8 +264,8 @@ class ParameterCollection(dict):
 
         Parameters
         ----------
-        *args : dict[str, Parameter] | Parameter | Self
-            Any number of Parameters or ParameterCollections or dictionaries
+        *args : Parameter or ParameterCollection
+            Any number of Parameters or ParameterCollections
             with key: Parameter pairs.
 
         Raises
@@ -260,9 +274,9 @@ class ParameterCollection(dict):
             If the kwargs key of a Parameter differs from the Parameter
             reference key.
         """
-        _flattened_params = flatten(
+        _flattened_params = flatten(  # type: ignore[arg-type]
             [_arg] if isinstance(_arg, Parameter) else list(_arg.values())
-            for _arg in args
+            for _arg in args  # type: ignore[arg-type]
         )
         _original_keys = tuple(self.keys())
         for _param in _flattened_params:
@@ -270,22 +284,22 @@ class ParameterCollection(dict):
             _temp_keys = _original_keys + _other_keys
             self.__check_key_available(_param, keys=_temp_keys)
 
-    def __add_arg_params(self, *args: tuple[Parameter, Self]):
+    def __add_arg_params(self, *args: "Parameter | ParameterCollection") -> None:
         """
         Add the passed parameters to the ParameterCollection.
 
         Parameters
         ----------
-        *args : tuple[Parameter, Self]
+        *args : Parameter or ParameterCollection
             The single Parameters or ParameterCollections to be added.
         """
-        for _item in args:
+        for _item in args:  # type: ignore[arg-type]
             if isinstance(_item, Parameter):
                 self.add_param(_item)
             elif isinstance(_item, ParameterCollection):
                 self.update(_item)
 
-    def delete_param(self, key: str):
+    def delete_param(self, key: str) -> None:
         """
         Remove a Parameter from the ParameterCollection.
 
@@ -298,7 +312,7 @@ class ParameterCollection(dict):
         """
         self.__delitem__(key)
 
-    def copy(self) -> Self:
+    def copy(self) -> "ParameterCollection":
         """
         Get a copy of the ParameterCollection.
 
@@ -312,7 +326,7 @@ class ParameterCollection(dict):
         """
         return self.__copy__()
 
-    def deepcopy(self) -> Self:
+    def deepcopy(self) -> "ParameterCollection":
         """
         Get a copy of the ParameterCollection.
 
@@ -345,7 +359,7 @@ class ParameterCollection(dict):
         """
         return self.__getitem__(param_key).value
 
-    def set_value(self, param_key: str, value: Any):
+    def set_value(self, param_key: str, value: Any) -> None:
         """
         Update the value of a stored parameter.
 
@@ -427,7 +441,8 @@ class ParameterCollection(dict):
         _vals = set()
         for _arg in args:
             if _arg not in self.keys():
-                raise KeyError(f"No Parameter with the key {_arg} has been registered.")
+                _msg = f"No Parameter with the key {_arg} has been registered."
+                raise KeyError(_msg)
             _vals.add(self.get_value(_arg))
         if len(_vals) == 1:
             return True

--- a/src/pydidas/core/utils/hdf5/nxs_export.py
+++ b/src/pydidas/core/utils/hdf5/nxs_export.py
@@ -158,7 +158,7 @@ def create_nxdata_entry(
 def create_nx_dataset(
     group: h5py.Group,
     name: str,
-    data: dict | np.ndarray | str | Number,
+    data: dict[str, Any] | np.ndarray | str | Number,
     **attributes: Any,
 ) -> h5py.Dataset:
     """
@@ -188,7 +188,9 @@ def create_nx_dataset(
     return _dataset
 
 
-def nx_dataset_config_from_param(param: Parameter) -> tuple[Any, dict[str, Any]]:
+def nx_dataset_config_from_param(
+    param: Parameter,
+) -> tuple[dict[str, Any], dict[str, Any]]:
     """
     Get a dict with NXdata configuration from a Parameter.
 
@@ -199,7 +201,7 @@ def nx_dataset_config_from_param(param: Parameter) -> tuple[Any, dict[str, Any]]
 
     Returns
     -------
-    Any
+    dict[str, Any]
         The data to be stored in the dataset.
     dict[str, Any]
         The NXdata configuration dict.
@@ -210,7 +212,7 @@ def nx_dataset_config_from_param(param: Parameter) -> tuple[Any, dict[str, Any]]
     if param.name:
         _config["long_name"] = param.name
     _config["NX_class"] = _get_nx_class_for_param(param)
-    return param.value_for_export, _config
+    return {"data": param.value_for_export}, _config
 
 
 def _get_nx_class_for_param(param: Parameter) -> str:

--- a/src/pydidas/gui/frames/view_results_frame.py
+++ b/src/pydidas/gui/frames/view_results_frame.py
@@ -316,5 +316,5 @@ class ViewResultsFrame(BaseFrameWithApp):
             _formats,
             overwrite=_overwrite,
             node_id=node,
-            squeeze_results=_squeeze_flag,
+            squeeze=_squeeze_flag,
         )

--- a/src/pydidas/unittest_objects/create_hdf5_io_file_.py
+++ b/src/pydidas/unittest_objects/create_hdf5_io_file_.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -16,12 +16,12 @@
 # along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
 
 """
-Function to create hdf5 files which are compatible with the ProcessingResults hdf5
+Functions to create HDF5 files compatible with the pydidas HDF5 result
 importer/exporter.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -30,9 +30,9 @@ __all__ = ["create_hdf5_io_file", "create_hdf5_results_file"]
 
 import os.path
 from pathlib import Path
-from typing import NewType, Union
+from typing import Any
 
-import h5py
+import h5py  # type: ignore[import-untyped]
 
 from pydidas.contexts import DiffractionExperiment, Scan
 from pydidas.core import Dataset, UserConfigError
@@ -40,44 +40,88 @@ from pydidas.version import VERSION
 from pydidas.workflow import ProcessingTree
 
 
-WorkflowTree = NewType("WorkflowTree", type)
-
-
-def create_hdf5_results_file(
-    filename: Union[Path, str],
+def create_hdf5_io_file(
+    filename: Path | str,
     data: Dataset,
-    scan: Union[Scan, dict],
-    diffraction_exp: Union[DiffractionExperiment, dict],
-    workflow: Union[WorkflowTree, str],
-    **kwargs: dict,
-):
+    **kwargs: Any,
+) -> None:
     """
     Create a Hdf5 file from a dataset which can be read by the Hdf5 importer.
 
     Parameters
     ----------
-    filename : Union[str, pathlib.Path]
+    filename : str or Path
         The output filename.
     data : Dataset
         The data to be written.
-    scan : Union[Scan, dict]
-        The Scan or its parameter. The Scan can be either passed as instance or
-         its Parameter keys and values as dict (in exportable types).
-    diffraction_exp : Union[DiffractionExperiment, dict]
+    **kwargs : Any
+        Any optional kwargs passed to the function. Supported arguments are
+
+        dataset : str, optional
+            The name of the hdf5 dataset where the data is stored. The default
+            is entry/data/data
+        write_mode : str, optional
+            The mode to write the hdf5 file (`w`) or to append to the file
+            (`r+`). The default is `w` for writing a new file.
+    """
+    _dataset = kwargs.get("dataset", "entry/data/data")
+    _data_group_name = os.path.dirname(_dataset)
+    _root_group_name = os.path.dirname(_data_group_name)  # type: ignore[arg-type]
+    _key = os.path.basename(_dataset)
+    _mode = kwargs.get("write_mode", "w")
+    with h5py.File(filename, _mode) as _file:
+        _root_group = _file.create_group(_root_group_name)
+        _data_group = _file.create_group(_data_group_name)
+        _root_group.create_dataset("data_label", data=data.data_label)
+        _root_group.create_dataset("data_unit", data=data.data_unit)
+        _data_group.create_dataset(_key, data=data.array)
+        for _dim in range(data.ndim):
+            _group = _data_group.create_group(f"axis_{_dim}")
+            _group.create_dataset("label", data=data.axis_labels[_dim])
+            _group.create_dataset("unit", data=data.axis_units[_dim])
+            _group.create_dataset("range", data=data.axis_ranges[_dim])
+
+
+def create_hdf5_results_file(
+    filename: Path | str,
+    data: Dataset,
+    scan: Scan | dict,
+    diffraction_exp: DiffractionExperiment | dict,
+    workflow: ProcessingTree | str,
+    **kwargs: Any,
+) -> None:
+    """
+    Create a Hdf5 file from a dataset which can be read by the Hdf5 importer.
+
+    Parameters
+    ----------
+    filename : str or Path
+        The output filename.
+    data : Dataset
+        The data to be written.
+    scan : Scan or dict
+        The Scan or its parameter. The Scan can be either passed as instance
+        or its Parameter keys and values as dict (in exportable types).
+    diffraction_exp : DiffractionExperiment or dict
         The DiffractionExperiment or its parameter. The DiffractionExperiment
-        can be either passed as instance or its Parameter keys and values as dict
-        (in exportable types).
-    workflow : Union[WorkflowTree, str]
-        The WorkflowTree instance or its string representation.
-    **kwargs : dict
+        can be either passed as instance or its Parameter keys and values as
+        dict (in exportable types).
+    workflow : ProcessingTree or str
+        The ProcessingTree instance or its string representation.
+    **kwargs
         Any optional kwargs passed to the function. Supported arguments are
 
         dataset : str
             The name of the hdf5 dataset where the data is stored.
-        node_label : str
-            The label of the pydidas processing node.
-        plugin_name : str
+        node_id : int, optional
+            The node ID for the results. The default is -1.
+        node_label : str, optional
+            The label of the pydidas processing node. The default is "".
+        plugin_name : str, optional
             The name of the pydidas plugin which `writes` this data.
+            The default is "".
+        scan_title : str, optional
+            The scan title. The default is "".
     """
     if isinstance(scan, Scan):
         scan = scan.get_param_values_as_dict(filter_types_for_export=True)
@@ -88,7 +132,8 @@ def create_hdf5_results_file(
     if isinstance(workflow, ProcessingTree):
         workflow = workflow.export_to_string()
     _dataset = kwargs.get("dataset", "entry/data/data")
-    _root_group_name = os.path.dirname(os.path.dirname(_dataset))
+    _dataset_inner = os.path.dirname(_dataset)  # type: ignore[arg-type]
+    _root_group_name = os.path.dirname(_dataset_inner)  # type: ignore[arg-type]
     if _root_group_name == "":
         raise UserConfigError(
             "The hdf5 dataset path is too shallow to allow writing all metadata. "
@@ -111,45 +156,3 @@ def create_hdf5_results_file(
             _diff_exp_group.create_dataset(_key, data=_value)
         _config_group.create_dataset("workflow", data=workflow)
         _config_group.create_dataset("pydidas_version", data=VERSION)
-
-
-def create_hdf5_io_file(
-    filename: Union[Path, str],
-    data: Dataset,
-    **kwargs: dict,
-):
-    """
-    Create a Hdf5 file from a dataset which can be read by the Hdf5 importer.
-
-    Parameters
-    ----------
-    filename : Union[str, pathlib.Path]
-        The output filename.
-    data : Dataset
-        The data to be written.
-    **kwargs : dict
-        Any optional kwargs passed to the function. Supported arguments are
-
-        dataset : str, optional
-            The name of the hdf5 dataset where the data is stored. The default
-            is entry/data/data
-        write_mode : str, optional
-        The mode to write the hdf5 file (`w`) or to append to the file (`r+`).
-        The default is `w` for writing a new file.
-    """
-    _dataset = kwargs.get("dataset", "entry/data/data")
-    _data_group_name = os.path.dirname(_dataset)
-    _root_group_name = os.path.dirname(_data_group_name)
-    _key = os.path.basename(_dataset)
-    _mode = kwargs.get("write_mode", "w")
-    with h5py.File(filename, _mode) as _file:
-        _root_group = _file.create_group(_root_group_name)
-        _data_group = _file.create_group(_data_group_name)
-        _root_group.create_dataset("data_label", data=data.data_label)
-        _root_group.create_dataset("data_unit", data=data.data_unit)
-        _data_group.create_dataset(_key, data=data.array)
-        for _dim in range(data.ndim):
-            _group = _data_group.create_group(f"axis_{_dim}")
-            _group.create_dataset("label", data=data.axis_labels[_dim])
-            _group.create_dataset("unit", data=data.axis_units[_dim])
-            _group.create_dataset("range", data=data.axis_ranges[_dim])

--- a/src/pydidas/unittest_objects/create_hdf5_io_file_.py
+++ b/src/pydidas/unittest_objects/create_hdf5_io_file_.py
@@ -30,7 +30,7 @@ __all__ = ["create_hdf5_io_file", "create_hdf5_results_file"]
 
 import os.path
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 import h5py  # type: ignore[import-untyped]
 
@@ -152,9 +152,15 @@ def create_hdf5_results_file(
         _root.create_dataset("node_label", data=kwargs.get("node_label", ""))
         _root.create_dataset("plugin_name", data=kwargs.get("plugin_name", ""))
         _root.create_dataset("scan_title", data=kwargs.get("scan_title", ""))
-        _config_group.create_dataset(
-            "squeezed_scan_dims", data=kwargs.get("squeezed_scan_dims", [])
-        )
+        _squeezed_dims = kwargs.get("squeezed_scan_dims", "")
+        if _squeezed_dims:
+            if isinstance(_squeezed_dims, Iterable):
+                _squeezed_dims = ",".join(str(_item) for _item in _squeezed_dims)
+            if not isinstance(_squeezed_dims, str):
+                raise UserConfigError(
+                    "Squeezed scan dimensions must be a string or list of integers."
+                )
+        _config_group.create_dataset("squeezed_scan_dims", data=_squeezed_dims)
         for _key, _value in scan.items():
             _scan_group.create_dataset(_key, data=_value)
         for _key, _value in diffraction_exp.items():

--- a/src/pydidas/unittest_objects/create_hdf5_io_file_.py
+++ b/src/pydidas/unittest_objects/create_hdf5_io_file_.py
@@ -154,11 +154,13 @@ def create_hdf5_results_file(
         _root.create_dataset("scan_title", data=kwargs.get("scan_title", ""))
         _squeezed_dims = kwargs.get("squeezed_scan_dims", "")
         if _squeezed_dims:
-            if isinstance(_squeezed_dims, Iterable):
-                _squeezed_dims = ",".join(str(_item) for _item in _squeezed_dims)
-            if not isinstance(_squeezed_dims, str):
+            if isinstance(_squeezed_dims, str):
+                pass
+            elif isinstance(_squeezed_dims, Iterable):
+                _squeezed_dims = ";".join(str(_item) for _item in _squeezed_dims)
+            else:
                 raise UserConfigError(
-                    "Squeezed scan dimensions must be a string or list of integers."
+                    "Squeezed scan dimensions must be a string or an iterable of integers."
                 )
         _config_group.create_dataset("squeezed_scan_dims", data=_squeezed_dims)
         for _key, _value in scan.items():

--- a/src/pydidas/unittest_objects/create_hdf5_io_file_.py
+++ b/src/pydidas/unittest_objects/create_hdf5_io_file_.py
@@ -122,6 +122,8 @@ def create_hdf5_results_file(
             The default is "".
         scan_title : str, optional
             The scan title. The default is "".
+        squeezed_scan_dims : list[int], optional
+            The squeezed scan dimensions. The default is [].
     """
     if isinstance(scan, Scan):
         scan = scan.get_param_values_as_dict(filter_types_for_export=True)
@@ -150,6 +152,9 @@ def create_hdf5_results_file(
         _root.create_dataset("node_label", data=kwargs.get("node_label", ""))
         _root.create_dataset("plugin_name", data=kwargs.get("plugin_name", ""))
         _root.create_dataset("scan_title", data=kwargs.get("scan_title", ""))
+        _config_group.create_dataset(
+            "squeezed_scan_dims", data=kwargs.get("squeezed_scan_dims", [])
+        )
         for _key, _value in scan.items():
             _scan_group.create_dataset(_key, data=_value)
         for _key, _value in diffraction_exp.items():

--- a/src/pydidas/workflow/processing_results.py
+++ b/src/pydidas/workflow/processing_results.py
@@ -552,7 +552,7 @@ class ProcessingResults(ObjectWithParameterCollection):
         save_dir: str | Path,
         *save_formats: str,
         overwrite: bool = False,
-        squeeze_results: bool = False,
+        squeeze: bool = False,
         node_id: int | None = None,
     ):
         """
@@ -576,7 +576,7 @@ class ProcessingResults(ObjectWithParameterCollection):
             (","), ampersand ("&") or slash ("/") characters.
         overwrite : bool, optional
             Flag to enable overwriting of existing files. The default is False.
-        squeeze_results : bool, optional
+        squeeze : bool, optional
             Flag to enable squeezing of empty dimensions. The default is False.
         node_id : int or None, optional
             The node ID for which data shall be saved. If None, this defaults
@@ -587,7 +587,7 @@ class ProcessingResults(ObjectWithParameterCollection):
             ",".join(save_formats),
             overwrite,
             single_node=node_id,
-            squeeze_results=squeeze_results,
+            squeeze=squeeze,
         )
         if node_id is None:
             _res = self._composites
@@ -596,7 +596,7 @@ class ProcessingResults(ObjectWithParameterCollection):
         ResultSaver.export_full_data_to_active_savers(
             _res,
             scan_context=self._config["frozen_SCAN"],
-            squeeze_results=squeeze_results,
+            squeeze=squeeze,
         )
 
     # alias
@@ -608,7 +608,7 @@ class ProcessingResults(ObjectWithParameterCollection):
         save_formats: str,
         overwrite: bool = False,
         single_node: int | None = None,
-        squeeze_results: bool = False,
+        squeeze: bool = False,
     ):
         """
         Prepare the required files and directories for saving.
@@ -629,7 +629,7 @@ class ProcessingResults(ObjectWithParameterCollection):
         single_node: int or None, optional
             Keyword to select a single node. If None, all nodes will be
             selected. The default is None.
-        squeeze_results : bool, optional
+        squeeze : bool, optional
             Flag to enable squeezing of empty dimensions. The default is False.
 
         Raises
@@ -654,7 +654,7 @@ class ProcessingResults(ObjectWithParameterCollection):
             _id: {
                 "shape": (
                     self._config["shapes"][_id]
-                    if not squeeze_results
+                    if not squeeze
                     else tuple(_n for _n in self._config["shapes"][_id] if _n > 1)
                 ),
                 "node_label": self._config["node_labels"][_id],
@@ -683,7 +683,7 @@ class ProcessingResults(ObjectWithParameterCollection):
         self,
         node_id: int,
         use_scan_timeline: bool = False,
-        squeeze_results: bool = True,
+        squeeze: bool = True,
     ) -> str:
         """
         Get the edited metadata from ProcessingResults as a formatted string.
@@ -695,7 +695,7 @@ class ProcessingResults(ObjectWithParameterCollection):
         use_scan_timeline : bool, optional
             The flag whether to reduce the scan dimensions to a single
             timeline. The default is False.
-        squeeze_results : bool, optional
+        squeeze : bool, optional
             Flag whether to squeeze the results (i.e. remove all dimensions of length 1)
             from the data. The default is True.
 
@@ -718,7 +718,7 @@ class ProcessingResults(ObjectWithParameterCollection):
             ),
             "axis_points": list(_metadata["shape"]),
         }
-        if squeeze_results:
+        if squeeze:
             _squeezed_dims = np.where(np.asarray(_print_info["axis_points"]) == 1)[0]
             _print_info = {
                 _key: [

--- a/src/pydidas/workflow/result_io/processing_result_io_base.py
+++ b/src/pydidas/workflow/result_io/processing_result_io_base.py
@@ -30,7 +30,7 @@ __all__ = ["ProcessingResultIoBase"]
 
 import re
 from pathlib import Path
-from typing import Union
+from typing import Any
 
 from pydidas.contexts.scan import Scan
 from pydidas.core import Dataset
@@ -40,7 +40,7 @@ from pydidas.workflow.result_io.processing_result_io_meta import ProcessingResul
 
 class ProcessingResultIoBase(GenericIoBase, metaclass=ProcessingResultIoMeta):
     """
-    Base class for WorkflowTree exporters.
+    Base class for processing result importers and exporters.
     """
 
     extensions = []
@@ -51,34 +51,34 @@ class ProcessingResultIoBase(GenericIoBase, metaclass=ProcessingResultIoMeta):
 
     @classmethod
     def prepare_files_and_directories(
-        cls, save_dir: Union[Path, str], node_information: dict, **kwargs
-    ):
+        cls, save_dir: Path | str, node_information: dict, **kwargs: Any
+    ) -> None:
         """
         Prepare the required files and directories to write the data to disk.
 
         Parameters
         ----------
-        save_dir : Union[Path, str]
+        save_dir : Path or str
             The full path for the data to be saved.
         node_information : dict
             A dictionary with nodeID keys and dictionary values. Each value dictionary
             must have the following keys: shape, node_label, data_label, plugin_name
-            and the respecive values. The shape (tuple) detemines the shape of the
+            and the respective values. The shape (tuple) determines the shape of the
             Dataset, the node_label is the user's name for the processing node. The
             data_label gives the description of what the data shows (e.g. intensity)
             and the plugin_name is simply the name of the plugin.
         **kwargs:
             Supported kwargs are:
 
-            scan_context : Union[Scan, None], optional
+            scan_context : Scan or None, optional
                 The scan context. If None, the generic context will be used.
                 Only specify this, if you explicitly require a different context.
                 The default is None.
-            diffraction_exp_context : Union[DiffractionExp, None], optional
+            diffraction_exp_context : DiffractionExp or None, optional
                 The diffraction experiment context. If None, the generic context
                 will be used. Only specify this, if you explicitly require a
                 different context. The default is None.
-            workflow_tree : Union[WorkflowTree, None], optional
+            workflow_tree : WorkflowTree or None, optional
                 The WorkflowTree. If None, the generic WorkflowTree will be used.
                 Only specify this, if you explicitly require a different context.
                 The default is None.
@@ -88,7 +88,7 @@ class ProcessingResultIoBase(GenericIoBase, metaclass=ProcessingResultIoMeta):
     @classmethod
     def get_attribute_dict(cls, name: str) -> dict:
         """
-        Get a dictionary for a single attribute from the combined node informatinon.
+        Get a dictionary for a single attribute from the combined node information.
 
         Parameters
         ----------
@@ -116,13 +116,13 @@ class ProcessingResultIoBase(GenericIoBase, metaclass=ProcessingResultIoMeta):
 
         Returns
         -------
-        type
+        object
             The value of the required attribute
         """
         return cls._node_information[node_id][name]
 
     @classmethod
-    def get_filenames_from_labels(cls, labels: Union[dict, None] = None):
+    def get_filenames_from_labels(cls, labels: dict | None = None) -> dict:
         """
         Get the directory names from labels.
 
@@ -132,7 +132,7 @@ class ProcessingResultIoBase(GenericIoBase, metaclass=ProcessingResultIoMeta):
 
         Parameters
         ----------
-        labels : Union[dict, None], optional
+        labels : dict or None, optional
             The labels to be used. If labels are not supplied, they will be taken from
             the internally stored node information. The default is None.
 
@@ -159,8 +159,9 @@ class ProcessingResultIoBase(GenericIoBase, metaclass=ProcessingResultIoMeta):
     def export_full_data_to_file(
         cls,
         full_data: dict[int, Dataset],
-        scan_context: Union[Scan, None] = None,
-    ):
+        scan_context: Scan | None = None,
+        squeeze: bool = False,
+    ) -> None:
         """
         Export all specified datasets to disk.
 
@@ -173,16 +174,20 @@ class ProcessingResultIoBase(GenericIoBase, metaclass=ProcessingResultIoMeta):
         ----------
         full_data : dict
             The result dictionary with nodeID keys and result values.
-        scan_context : Union[Scan, None], optional
+        scan_context : Scan or None, optional
             The scan context. If None, the generic context will be used. Only specify
             this, if you explicitly require a different context. The default is None.
+        squeeze : bool, optional
+            Flag to toggle squeezing of the data. If True, any empty dimensions will
+            be squeezed from the data. The default is False.
+
         """
         raise NotImplementedError
 
     @classmethod
     def export_frame_to_file(
-        cls, index: int, frame_result_dict: dict[int, Dataset], **kwargs: dict
-    ):
+        cls, index: int, frame_result_dict: dict[int, Dataset], **kwargs: Any
+    ) -> None:
         """
         Export the results of one frame and store them on disk.
 
@@ -197,13 +202,13 @@ class ProcessingResultIoBase(GenericIoBase, metaclass=ProcessingResultIoMeta):
             The frame index.
         frame_result_dict : dict
             The result dictionary with nodeID keys and result values.
-        **kwargs : dict
-            Any kwargs which should be passed to the udnerlying exporter.
+        **kwargs
+            Any kwargs which should be passed to the underlying exporter.
         """
         raise NotImplementedError
 
     @classmethod
-    def update_frame_metadata(cls, metadata: dict, scan: Union[Scan, None] = None):
+    def update_frame_metadata(cls, metadata: dict, scan: Scan | None = None) -> None:
         """
         Update the metadata of the individual frame.
 
@@ -216,20 +221,20 @@ class ProcessingResultIoBase(GenericIoBase, metaclass=ProcessingResultIoMeta):
         ----------
         metadata : dict
             The metadata dictionary with results of one frame for each node.
-        scan : Union[pydidas.contexts.scan.Scan, None], optional
+        scan : Scan or None, optional
             The Scan instance. If None, this will default to the generic ScanContext.
             The default is None.
         """
         raise NotImplementedError
 
     @classmethod
-    def import_results_from_file(cls, filename: Union[Path, str]):
+    def import_results_from_file(cls, filename: Path | str) -> tuple[Dataset, dict, dict]:
         """
         Import results from a file and store them as a Dataset.
 
         Parameters
         ----------
-        filename : Union[Path, str]
+        filename : Path or str
             The full filename of the file to be imported.
 
         Raises
@@ -239,7 +244,7 @@ class ProcessingResultIoBase(GenericIoBase, metaclass=ProcessingResultIoMeta):
 
         Returns
         -------
-        data : pydidas.core.Dataset
+        data : Dataset
             The dataset with the imported data.
         node_info : dict
             A dictionary with node_label, data_label, plugin_name keys and the

--- a/src/pydidas/workflow/result_io/processing_result_io_base.py
+++ b/src/pydidas/workflow/result_io/processing_result_io_base.py
@@ -32,9 +32,10 @@ import re
 from pathlib import Path
 from typing import Any
 
-from pydidas.contexts.scan import Scan
+from pydidas.contexts import DiffractionExperiment, Scan
 from pydidas.core import Dataset
 from pydidas.core.io_registry import GenericIoBase
+from pydidas.workflow.processing_tree import ProcessingTree
 from pydidas.workflow.result_io.processing_result_io_meta import ProcessingResultIoMeta
 
 
@@ -150,7 +151,7 @@ class ProcessingResultIoBase(GenericIoBase, metaclass=ProcessingResultIoMeta):
             else:
                 _label = re.sub("[^a-zA-Z0-9_-]", "_", _label)
                 _label = re.sub("_+", "_", _label).strip("_")
-                _names[_id] = (f"node_{_id:02d}_{_label}{cls.default_suffix}").replace(
+                _names[_id] = f"node_{_id:02d}_{_label}{cls.default_suffix}".replace(
                     "__", "_"
                 )
         return _names
@@ -228,7 +229,9 @@ class ProcessingResultIoBase(GenericIoBase, metaclass=ProcessingResultIoMeta):
         raise NotImplementedError
 
     @classmethod
-    def import_results_from_file(cls, filename: Path | str) -> tuple[Dataset, dict, dict]:
+    def import_results_from_file(
+        cls, filename: Path | str
+    ) -> tuple[Dataset, dict[str, Any], Scan, DiffractionExperiment, ProcessingTree]:
         """
         Import results from a file and store them as a Dataset.
 
@@ -244,12 +247,16 @@ class ProcessingResultIoBase(GenericIoBase, metaclass=ProcessingResultIoMeta):
 
         Returns
         -------
-        data : Dataset
+        data : pydidas.core.Dataset
             The dataset with the imported data.
         node_info : dict
-            A dictionary with node_label, data_label, plugin_name keys and the
-            respective values.
-        scan : dict
-            The dictionary with meta information about the scan.
+            A dictionary with node_label, data_label, plugin_name keys and
+            the respective values.
+        scan : pydidas.contexts.Scan
+            The imported scan configuration.
+        diffraction_exp : pydidas.contexts.DiffractionExperiment
+            The imported diffraction experiment configuration.
+        tree : pydidas.workflow.WorkflowTree
+            The imported workflow tree.
         """
         raise NotImplementedError

--- a/src/pydidas/workflow/result_io/processing_result_io_hdf5.py
+++ b/src/pydidas/workflow/result_io/processing_result_io_hdf5.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 import h5py
+import numpy as np
 
 from pydidas.contexts import DiffractionExperimentContext, ScanContext
 from pydidas.contexts.diff_exp import DiffractionExperiment
@@ -64,9 +65,9 @@ _DEFAULT_GROUPS = [
 ]
 
 
-def _get_pydidas_context_config_entries(
+def _context_config_entries(
     scan: Scan, exp: DiffractionExperiment, tree: ProcessingTree
-) -> list[list[str | dict]]:
+) -> list[tuple[str, str, Any, dict[str, Any]]]:
     """
     Get the context configuration from the pydidas Context singletons.
 
@@ -81,64 +82,59 @@ def _get_pydidas_context_config_entries(
 
     Returns
     -------
-    list[list[str, dict]]
-        The writable entries for the contexts.
+    list[tuple[str, str, Any, dict[str, Any]]]
+        The writable entries for the contexts in the form of a list of
+        tuples with group name, dataset name, data and data attributes.
     """
-    _dsets = []
+    _dsets: list[tuple[str, str, Any, dict[str, Any]]] = []
     for _key, _param in scan.params.items():
-        _dsets.append(
-            [
-                "entry/pydidas_config/scan",
-                _key,
-                *nx_dataset_config_from_param(_param),
-            ]
-        )
+        _data_cfg, _nx_attrs = nx_dataset_config_from_param(_param)
+        _dsets.append(("entry/pydidas_config/scan", _key, _data_cfg, _nx_attrs))
     for _key, _param in exp.params.items():
+        _data_cfg, _nx_attrs = nx_dataset_config_from_param(_param)
         _dsets.append(
-            [
-                "entry/pydidas_config/diffraction_exp",
-                _key,
-                *nx_dataset_config_from_param(_param),
-            ]
+            ("entry/pydidas_config/diffraction_exp", _key, _data_cfg, _nx_attrs)
         )
-    _dsets += [
+    _dsets.extend(
         [
-            "entry/pydidas_config",
-            "workflow",
-            {"data": tree.export_to_string()},
-            {"NX_class": "NX_CHAR", "units": ""},
-        ],
-        [
-            "entry/pydidas_config",
-            "pydidas_version",
-            {"data": VERSION},
-            {"NX_class": "NX_CHAR", "units": ""},
-        ],
-        [
-            "entry/instrument/detector/COLLECTION",
-            "frame_start_number",
-            {"data": scan.get_param_value("pattern_number_offset")},
-            {"NX_class": "NX_INT", "units": ""},
-        ],
-        [
-            "entry/instrument/detector",
-            "x_pixel_size",
-            {"data": exp.get_param_value("detector_pxsizex")},
-            {"NX_class": "NX_FLOAT", "units": "um"},
-        ],
-        [
-            "entry/instrument/detector",
-            "y_pixel_size",
-            {"data": exp.get_param_value("detector_pxsizey")},
-            {"NX_class": "NX_FLOAT", "units": "um"},
-        ],
-        [
-            "entry/instrument/detector",
-            "distance",
-            {"data": exp.get_param_value("detector_dist")},
-            {"NX_class": "NX_FLOAT", "units": "m"},
-        ],
-    ]
+            (
+                "entry/pydidas_config",
+                "workflow",
+                {"data": tree.export_to_string()},
+                {"NX_class": "NX_CHAR", "units": ""},
+            ),
+            (
+                "entry/pydidas_config",
+                "pydidas_version",
+                {"data": VERSION},
+                {"NX_class": "NX_CHAR", "units": ""},
+            ),
+            (
+                "entry/instrument/detector/COLLECTION",
+                "frame_start_number",
+                {"data": scan.get_param_value("pattern_number_offset")},
+                {"NX_class": "NX_INT", "units": ""},
+            ),
+            (
+                "entry/instrument/detector",
+                "x_pixel_size",
+                {"data": exp.get_param_value("detector_pxsizex")},
+                {"NX_class": "NX_FLOAT", "units": "um"},
+            ),
+            (
+                "entry/instrument/detector",
+                "y_pixel_size",
+                {"data": exp.get_param_value("detector_pxsizey")},
+                {"NX_class": "NX_FLOAT", "units": "um"},
+            ),
+            (
+                "entry/instrument/detector",
+                "distance",
+                {"data": exp.get_param_value("detector_dist")},
+                {"NX_class": "NX_FLOAT", "units": "m"},
+            ),
+        ]
+    )
     return _dsets
 
 
@@ -239,7 +235,7 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
         scan: Scan,
         exp: DiffractionExperiment,
         workflow: ProcessingTree,
-    ) -> list[list[str | dict]]:
+    ) -> list[tuple[str, str, Any, dict[str, Any]]]:
         """
         Get the datasets to be written to the hdf5 file.
 
@@ -256,44 +252,46 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
 
         Returns
         -------
-        list[list[str, dict]]
-            The list with the dataset information to be written.
+        list[tuple[str, str, Any, dict[str, Any]]]
+            The list with the dataset information to be written. Each tuple
+            contains the HDF5 group name, key name, data to be written and
+            a NeXus attributes dictionary.
         """
 
         _node_attribute = partial(cls.get_node_attribute, node_id)
-        _dsets = [
-            [
+        _dsets: list[tuple[str, str, Any, dict[str, Any]]] = [
+            (
                 "entry",
                 "scan_title",
                 {"data": cls.scan_title},
                 {"NX_class": "NX_CHAR", "units": ""},
-            ],
-            [
+            ),
+            (
                 "entry",
                 "node_id",
                 {"data": node_id},
                 {"NX_class": "NX_INT", "units": ""},
-            ],
-            [
+            ),
+            (
                 "entry",
                 "node_label",
                 {"data": _node_attribute("node_label")},
                 {"NX_class": "NX_CHAR", "units": ""},
-            ],
-            [
+            ),
+            (
                 "entry",
                 "plugin_name",
                 {"data": _node_attribute("plugin_name")},
                 {"NX_class": "NX_CHAR", "units": ""},
-            ],
-            [
+            ),
+            (
                 "entry/data",
                 "data",
                 {"shape": _node_attribute("shape")},
                 {"NX_class": "NX_INT", "units": ""},
-            ],
+            ),
         ]
-        _dsets = _dsets + _get_pydidas_context_config_entries(scan, exp, workflow)  # type: ignore[operator]
+        _dsets.extend(_context_config_entries(scan, exp, workflow))  # type: ignore[arg-type]
         return _dsets
 
     @classmethod
@@ -323,7 +321,7 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
         _indices = _scan.get_indices_from_ordinal(index)
         if not cls._metadata_written:
             _metadata = cls.update_with_scan_metadata(frame_result_dict, _scan)
-            cls.update_metadata(_metadata)
+            cls.update_metadata(_metadata, scan=_scan)
         for _node_id, _data in frame_result_dict.items():
             _file_path = cls._save_dir / cls._filenames[_node_id]
             with h5py.File(_file_path, "r+") as _file:  # type: ignore[operator]
@@ -352,7 +350,7 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
             will be squeezed to remove empty dimensions. The default is False.
         """
         if not cls._metadata_written:
-            cls.update_metadata(full_data, squeeze=squeeze)
+            cls.update_metadata(full_data, scan=scan_context, squeeze=squeeze)
         for _node_id, _data in full_data.items():
             if squeeze:
                 _data = _data.squeeze()
@@ -362,8 +360,8 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
 
     @classmethod
     def update_with_scan_metadata(
-        cls, metadata: dict[int, Dataset | dict], scan: Scan
-    ) -> dict[int, dict]:
+        cls, metadata: dict[int, Dataset] | dict[int, dict[str, Any]], scan: Scan
+    ) -> dict[int, dict[str, Any]]:
         """
         Update the frame metadata with the scan metadata.
 
@@ -372,24 +370,27 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
 
         Parameters
         ----------
-        metadata : dict[int, Dataset or dict]
+        metadata : dict[int, Dataset] or dict[int, dict[str, Any]]
             The metadata in dictionary form with entries of the form
-            node_id: node_metadata.
+            node_id: node_metadata or node_id: Dataset.
+            If the Dataset is given, the metadata will be read from the
+            Dataset.
         scan : Scan
             The scan context to be used for metadata information.
 
         Returns
         -------
-        dict[int, dict]
-            The updated metadata.
+        dict[int, dict[str, Any]]
+            The updated metadata in a dictionary.
         """
         _scan_dim_labels = scan.axis_labels
         _scan_dim_units = scan.axis_units
         _scan_dim_ranges = scan.axis_ranges
         _new_metadata = {}
-        for _id, _metadata in metadata.items():
-            if isinstance(_metadata, Dataset):
-                _metadata = _metadata.property_dict
+        for _id, _entry in metadata.items():
+            _metadata: dict[str, Any] = (
+                _entry.property_dict if isinstance(_entry, Dataset) else _entry
+            )
             _metadata["axis_labels"] = {
                 _i: _label
                 for _i, _label in enumerate(
@@ -413,7 +414,10 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
 
     @classmethod
     def update_metadata(
-        cls, metadata: dict[int, Dataset | dict], squeeze: bool = False
+        cls,
+        metadata: dict[int, Dataset | dict[str, Any]],
+        scan: Scan | None = None,
+        squeeze: bool = False,
     ) -> None:
         """
         Update the frame metadata with a separately supplied metadata
@@ -421,13 +425,21 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
 
         Parameters
         ----------
-        metadata : dict[int, Dataset or dict]
+        metadata : dict[int, Dataset or dict[str, Any]]
             The metadata in dictionary form with entries of the form
             node_id: node_metadata.
+        scan : Scan or None, optional
+            The scan context. If None, the global ScanContext will be used.
+            The default is None.
         squeeze : bool, optional
             Flag to toggle squeezing of empty dimensions. If True, the data
             will be squeezed to remove empty dimensions. The default is False.
         """
+        _scan = ScanContext() if scan is None else scan
+        _squeezed_scan_dims = np.array(
+            [i for i, n in enumerate(_scan.shape) if n == 1] if squeeze else [],
+            dtype=int,
+        )
         for _id, _metadata in metadata.items():
             if isinstance(_metadata, Dataset):
                 if squeeze:
@@ -451,12 +463,53 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
                         long_name=_metadata["axis_labels"][_dim],
                         axis=_dim,
                     )
+                _file["entry/pydidas_config"].create_dataset(
+                    "squeezed_scan_dims", data=_squeezed_scan_dims
+                )
         cls._metadata_written = True
+
+    @classmethod
+    def _insert_squeezed_scan_dims(
+        cls,
+        data: Dataset,
+        scan: Scan,
+        dims: list[int],
+    ) -> Dataset:
+        """
+        Re-insert scan dimensions of size 1 that were squeezed during export.
+
+        Parameters
+        ----------
+        data : Dataset
+            The squeezed Dataset to reconstruct.
+        scan : Scan
+            The scan context containing the full scan definition.
+        dims : list[int]
+            The scan dimension indices that were squeezed (any order).
+
+        Returns
+        -------
+        Dataset
+            The Dataset with the squeezed scan dims re-inserted.
+        """
+        for _dim in sorted(dims):
+            _label, _unit, _range = scan.get_metadata_for_dim(_dim)  # type: ignore[arg-type]
+            _new_labels = [data.axis_labels[i] for i in range(data.ndim)]
+            _new_units = [data.axis_units[i] for i in range(data.ndim)]
+            _new_ranges = [data.axis_ranges[i] for i in range(data.ndim)]
+            _new_labels.insert(_dim, _label)
+            _new_units.insert(_dim, _unit)
+            _new_ranges.insert(_dim, _range)
+            data = np.expand_dims(data, axis=_dim)
+            data.axis_labels = _new_labels
+            data.axis_units = _new_units
+            data.axis_ranges = _new_ranges
+        return data  # type: ignore[return-value]
 
     @classmethod
     def import_results_from_file(
         cls, filename: Path | str
-    ) -> tuple[Dataset, dict, Scan, DiffractionExperiment, ProcessingTree]:
+    ) -> tuple[Dataset, dict[str, Any], Scan, DiffractionExperiment, ProcessingTree]:
         """
         Import results from a file and store them as a Dataset.
 
@@ -467,16 +520,16 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
 
         Returns
         -------
-        data : pydidas.core.Dataset
+        data : Dataset
             The dataset with the imported data.
-        node_info : dict
+        node_info : dict[str, Any]
             A dictionary with node_label, data_label, plugin_name keys and
             the respective values.
-        scan : pydidas.contexts.Scan
+        scan : Scan
             The imported scan configuration.
-        diffraction_exp : pydidas.contexts.DiffractionExperiment
+        diffraction_exp : DiffractionExperiment
             The imported diffraction experiment configuration.
-        tree : pydidas.workflow.WorkflowTree
+        tree : ProcessingTree
             The imported workflow tree.
         """
         _tree = ProcessingTree()
@@ -500,15 +553,42 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
                     "standard and cannot be imported. Please check the input file."
                 )
             _info = {
-                "node_label": read_and_decode_hdf5_dataset(_file["entry/node_label"]),  # type: ignore[arg-type]
-                "plugin_name": read_and_decode_hdf5_dataset(_file["entry/plugin_name"]),  # type: ignore[arg-type]
-                "node_id": read_and_decode_hdf5_dataset(_file["entry/node_id"]),  # type: ignore[arg-type]
+                "node_label": read_and_decode_hdf5_dataset(  # type: ignore[arg-type]
+                    _file["entry/node_label"]
+                ),
+                "plugin_name": read_and_decode_hdf5_dataset(  # type: ignore[arg-type]
+                    _file["entry/plugin_name"]
+                ),
+                "node_id": read_and_decode_hdf5_dataset(  # type: ignore[arg-type]
+                    _file["entry/node_id"]
+                ),
             }
             _info["result_title"] = (
                 f"{_info['node_label']} (node #{_info['node_id']:03d})"
                 if len(_info["node_label"]) > 0
                 else f"[{_info['plugin_name']}] (node #{_info['node_id']:03d})"
             )
+            try:
+                _squeezed_scan_dims = [
+                    int(x) for x in _file["entry/pydidas_config/squeezed_scan_dims"][()]
+                ]
+            except KeyError:
+                _squeezed_scan_dims = None
+
+        if _squeezed_scan_dims is None:
+            # Check in files written before the squeezed_scan_dims flag
+            # was introduced: if the scan has size-1 dims and the non-size-1
+            # scan shape prefix matches the start of the data shape, those
+            # size-1 dims were squeezed away during export.
+            _size_1_scan_dims = [i for i, n in enumerate(_scan.shape) if n == 1]
+            if _size_1_scan_dims:
+                _scan_shape_no_ones = tuple(n for n in _scan.shape if n > 1)
+                if _data.shape[: len(_scan_shape_no_ones)] == _scan_shape_no_ones:
+                    _data = cls._insert_squeezed_scan_dims(
+                        _data, _scan, _size_1_scan_dims
+                    )
+        elif len(_squeezed_scan_dims) > 0:
+            _data = cls._insert_squeezed_scan_dims(_data, _scan, _squeezed_scan_dims)
 
         _info["shape"] = _data.shape
         return _data, _info, _scan, _exp, _tree

--- a/src/pydidas/workflow/result_io/processing_result_io_hdf5.py
+++ b/src/pydidas/workflow/result_io/processing_result_io_hdf5.py
@@ -33,7 +33,6 @@ from pathlib import Path
 from typing import Any
 
 import h5py
-import numpy as np
 
 from pydidas.contexts import DiffractionExperimentContext, ScanContext
 from pydidas.contexts.diff_exp import DiffractionExperiment
@@ -46,6 +45,9 @@ from pydidas.core.utils.hdf5 import (
     read_and_decode_hdf5_dataset,
 )
 from pydidas.core.utils.hdf5.nxs_export import nx_dataset_config_from_param
+from pydidas.core.utils.iterable_utils import (
+    insert_item_in_tuple,
+)
 from pydidas.data_io import import_data
 from pydidas.version import VERSION
 from pydidas.workflow.processing_tree import ProcessingTree
@@ -388,7 +390,7 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
         _scan_dim_ranges = scan.axis_ranges
         _new_metadata = {}
         for _id, _entry in metadata.items():
-            _metadata: dict[str, Any] = (
+            _metadata: dict[str, Any] = (  # type: ignore[type]
                 _entry.property_dict if isinstance(_entry, Dataset) else _entry
             )
             _metadata["axis_labels"] = {
@@ -436,9 +438,10 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
             will be squeezed to remove empty dimensions. The default is False.
         """
         _scan = ScanContext() if scan is None else scan
-        _squeezed_scan_dims = np.array(
-            [i for i, n in enumerate(_scan.shape) if n == 1] if squeeze else [],
-            dtype=int,
+        _squeezed_scan_dims = (
+            ";".join([str(i) for i, n in enumerate(_scan.shape) if n == 1])
+            if squeeze
+            else ""
         )
         for _id, _metadata in metadata.items():
             if isinstance(_metadata, Dataset):
@@ -463,8 +466,12 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
                         long_name=_metadata["axis_labels"][_dim],
                         axis=_dim,
                     )
-                _file["entry/pydidas_config"].create_dataset(
-                    "squeezed_scan_dims", data=_squeezed_scan_dims
+                create_nx_dataset(
+                    _file["entry/pydidas_config"],
+                    "squeezed_scan_dims",
+                    {"data": _squeezed_scan_dims},
+                    NX_class="NX_CHAR",
+                    units="",
                 )
         cls._metadata_written = True
 
@@ -492,18 +499,15 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
         Dataset
             The Dataset with the squeezed scan dims re-inserted.
         """
+        _shape = data.shape
         for _dim in sorted(dims):
-            _label, _unit, _range = scan.get_metadata_for_dim(_dim)  # type: ignore[arg-type]
-            _new_labels = [data.axis_labels[i] for i in range(data.ndim)]
-            _new_units = [data.axis_units[i] for i in range(data.ndim)]
-            _new_ranges = [data.axis_ranges[i] for i in range(data.ndim)]
-            _new_labels.insert(_dim, _label)
-            _new_units.insert(_dim, _unit)
-            _new_ranges.insert(_dim, _range)
-            data = np.expand_dims(data, axis=_dim)
-            data.axis_labels = _new_labels
-            data.axis_units = _new_units
-            data.axis_ranges = _new_ranges
+            _shape = insert_item_in_tuple(_shape, _dim, 1)
+        data = data.reshape(_shape)  # type: ignore[type]
+        for _dim in sorted(dims):
+            _label, _unit, _range = scan.get_metadata_for_dim(_dim)
+            data.update_axis_label(_dim, _label)
+            data.update_axis_unit(_dim, _unit)
+            data.update_axis_range(_dim, _range)
         return data  # type: ignore[return-value]
 
     @classmethod
@@ -569,10 +573,14 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
                 else f"[{_info['plugin_name']}] (node #{_info['node_id']:03d})"
             )
             try:
-                _squeezed_scan_dims = [
-                    int(x) for x in _file["entry/pydidas_config/squeezed_scan_dims"][()]
-                ]
-            except KeyError:
+                _squeeze_str = read_and_decode_hdf5_dataset(
+                    _file["entry/pydidas_config/squeezed_scan_dims"]
+                )
+                if _squeeze_str:
+                    _squeezed_scan_dims = [int(_s) for _s in _squeeze_str.split(";")]
+                else:
+                    _squeezed_scan_dims = []
+            except (KeyError, ValueError, AttributeError):
                 _squeezed_scan_dims = None
 
         if _squeezed_scan_dims is None:
@@ -584,10 +592,8 @@ class ProcessingResultIoHdf5(ProcessingResultIoBase):
             if _size_1_scan_dims:
                 _scan_shape_no_ones = tuple(n for n in _scan.shape if n > 1)
                 if _data.shape[: len(_scan_shape_no_ones)] == _scan_shape_no_ones:
-                    _data = cls._insert_squeezed_scan_dims(
-                        _data, _scan, _size_1_scan_dims
-                    )
-        elif len(_squeezed_scan_dims) > 0:
+                    _squeezed_scan_dims = _size_1_scan_dims
+        if _squeezed_scan_dims is not None and len(_squeezed_scan_dims) > 0:
             _data = cls._insert_squeezed_scan_dims(_data, _scan, _squeezed_scan_dims)
 
         _info["shape"] = _data.shape

--- a/src/pydidas/workflow/result_io/processing_result_io_meta.py
+++ b/src/pydidas/workflow/result_io/processing_result_io_meta.py
@@ -228,30 +228,6 @@ class ProcessingResultIoMeta(GenericIoMeta):
             _saver.export_full_data_to_file(data, scan_context, squeeze=squeeze_results)
 
     @classmethod
-    def export_full_data_to_file(
-        cls,
-        extension: str,
-        data: dict[int, Dataset],
-        scan_context: Scan | None = None,
-    ):
-        """
-        Export the full data to all active savers.
-
-        Parameters
-        ----------
-        extension : str
-            The file extension for the saver.
-        data : dict
-            The result dictionary with nodeID keys and result values.
-        scan_context : Scan or None, optional
-            The scan context. If None, the generic context will be used. Only specify
-            this, if you explicitly require a different context. The default is None.
-        """
-        cls.verify_extension_is_registered(extension)
-        _saver = cls.registry[extension.lower()]
-        _saver.export_full_data_to_file(data, scan_context)
-
-    @classmethod
     def export_frame_to_file(
         cls,
         index: int,

--- a/src/pydidas/workflow/result_io/processing_result_io_meta.py
+++ b/src/pydidas/workflow/result_io/processing_result_io_meta.py
@@ -33,6 +33,7 @@ __all__ = ["ProcessingResultIoMeta"]
 
 import os
 from pathlib import Path
+from typing import Any
 
 from pydidas.contexts.diff_exp import DiffractionExperiment
 from pydidas.contexts.scan import Scan
@@ -207,7 +208,7 @@ class ProcessingResultIoMeta(GenericIoMeta):
         cls,
         data: dict[int, Dataset],
         scan_context: Scan | None = None,
-        squeeze_results: bool = False,
+        squeeze: bool = False,
     ):
         """
         Export the full data to all active savers.
@@ -219,13 +220,13 @@ class ProcessingResultIoMeta(GenericIoMeta):
         scan_context : Scan or None, optional
             The scan context. If None, the generic context will be used. Only specify
             this, if you explicitly require a different context. The default is None.
-        squeeze_results : bool, optional
+        squeeze : bool, optional
             Flag to toggle squeezing of the data. If True, any empty dimensions will
             be squeezed from the data. The default is False.
         """
         for _ext in cls.active_savers:
             _saver = cls.registry[_ext]
-            _saver.export_full_data_to_file(data, scan_context, squeeze=squeeze_results)
+            _saver.export_full_data_to_file(data, scan_context, squeeze=squeeze)
 
     @classmethod
     def export_frame_to_file(
@@ -233,7 +234,7 @@ class ProcessingResultIoMeta(GenericIoMeta):
         index: int,
         extension: str,
         frame_result_dict: dict[int, Dataset],
-        **kwargs: dict,
+        **kwargs: Any,
     ):
         """
         Call the concrete export_to_file method in the subclass registered
@@ -247,7 +248,7 @@ class ProcessingResultIoMeta(GenericIoMeta):
             The file extension for the saver.
         frame_result_dict : dict
             The result dictionary with nodeID keys and result values.
-        kwargs : dict
+        kwargs : Any
             Any kwargs which should be passed to the underlying exporter.
         """
         cls.verify_extension_is_registered(extension)

--- a/tests/contexts/scan/test_scan.py
+++ b/tests/contexts/scan/test_scan.py
@@ -24,8 +24,6 @@ __maintainer__ = "Malte Storm"
 __status__ = "Production"
 
 
-from typing import Any
-
 import numpy as np
 import pytest
 
@@ -34,32 +32,27 @@ from pydidas.core import UserConfigError
 from pydidas.core.utils import get_random_string
 
 
-_scan_param_values = {
-    "shape": (5, 7, 3, 2),
-    "delta": (0.1, 0.5, 1, 1.5),
-    "offset": (3, -1, 0, 0.5),
-    "scan_dim": 4,
-}
+_SCAN_SHAPE: tuple[int, ...] = (5, 7, 3, 2)
+_SCAN_DELTA: tuple[float | int, ...] = (0.1, 0.5, 1, 1.5)
+_SCAN_OFFSET: tuple[float | int, ...] = (3, -1, 0, 0.5)
+_SCAN_DIM: int = 4
 
 
-def set_scan_params(scan: Scan) -> dict[str, Any]:
-    scan.set_param_value("scan_dim", _scan_param_values["scan_dim"])
-    for index, val in enumerate(_scan_param_values["shape"]):
+def set_scan_params(scan: Scan) -> None:
+    scan.set_param_value("scan_dim", _SCAN_DIM)
+    for index, val in enumerate(_SCAN_SHAPE):
         scan.set_param_value(f"scan_dim{index}_n_points", val)
-    for index, val in enumerate(_scan_param_values["delta"]):
+    for index, val in enumerate(_SCAN_DELTA):
         scan.set_param_value(f"scan_dim{index}_delta", val)
-    for index, val in enumerate(_scan_param_values["offset"]):
+    for index, val in enumerate(_SCAN_OFFSET):
         scan.set_param_value(f"scan_dim{index}_offset", val)
 
 
 def get_scan_range(dim):
     return np.linspace(
-        _scan_param_values["offset"][dim],
-        (
-            _scan_param_values["offset"][dim]
-            + (_scan_param_values["shape"][dim] - 1) * _scan_param_values["delta"][dim]
-        ),
-        num=_scan_param_values["shape"][dim],
+        _SCAN_OFFSET[dim],
+        (_SCAN_OFFSET[dim] + (_SCAN_SHAPE[dim] - 1) * _SCAN_DELTA[dim]),
+        num=_SCAN_SHAPE[dim],
     )
 
 
@@ -71,13 +64,54 @@ def test_init():
 def test_n_total():
     scan = Scan()
     set_scan_params(scan)
-    assert scan.n_points == np.prod(_scan_param_values["shape"])
+    assert scan.n_points == np.prod(_SCAN_SHAPE)
 
 
 def test_shape():
     scan = Scan()
     set_scan_params(scan)
-    assert scan.shape == _scan_param_values["shape"]
+    assert scan.shape == _SCAN_SHAPE
+
+
+@pytest.mark.parametrize(
+    "scan_dim, n_points, expected_squeezed",
+    [
+        (4, (5, 7, 3, 2), (5, 7, 3, 2)),  # no squeezing needed
+        (4, (5, 1, 3, 1), (5, 3)),  # with single dimensions
+        (4, (1, 1, 1, 1), ()),  # all dimensions one
+        (3, (1, 10, 1), (10,)),  # single dimension nonzero
+        (4, (5, 1, 7, 1), (5, 7)),  # alternating pattern
+        (4, (1, 1, 4, 6), (4, 6)),  # ones at start
+        (4, (3, 5, 1, 1), (3, 5)),  # ones at end
+    ],
+)
+def test_squeezed_shape(scan_dim, n_points, expected_squeezed):
+    """Test squeezed_shape property with various dimension configurations.
+
+    Parameters
+    ----------
+    scan_dim : int
+        The number of scan dimensions to set.
+    n_points : tuple[int]
+        The number of points for each dimension.
+    expected_squeezed : tuple[int]
+        The expected squeezed shape (dimensions with n_points == 1 removed).
+    """
+    scan = Scan()
+    scan.set_param_value("scan_dim", scan_dim)
+    for i, n in enumerate(n_points):
+        scan.set_param_value(f"scan_dim{i}_n_points", n)
+    assert scan.squeezed_shape == expected_squeezed
+
+
+def test_squeezed_shape__default_scan():
+    """Test squeezed_shape on a default (uninitialized) scan."""
+    scan = Scan()
+    # Default scan should have all dimensions as 1
+    # Default scan_dim is 1, and scan_dim0_n_points should be 1
+    _squeezed = scan.squeezed_shape
+    assert isinstance(_squeezed, tuple)
+    # The result should be empty or contain only 1s removed
 
 
 def test_ndim():
@@ -123,7 +157,7 @@ def test_file_naming_pattern_w_index__multiple_counters(pattern):
     scan = Scan()
     scan.set_param_value("scan_name_pattern", pattern)
     with pytest.raises(UserConfigError):
-        scan.processed_file_naming_pattern
+        _ = scan.processed_file_naming_pattern
 
 
 @pytest.mark.parametrize(
@@ -142,9 +176,9 @@ def test_file_naming_pattern_w_index__no_counters(pattern):
 def test_update_filename_string(pattern):
     scan = Scan()
     scan.set_param_value("scan_name_pattern", pattern)
-    _nhash = pattern.count("#")
-    _parts = pattern.split("#" * _nhash)
-    _parts.insert(1, "{index:0" + str(_nhash) + "d}")
+    _n_hash = pattern.count("#")
+    _parts = pattern.split("#" * _n_hash)
+    _parts.insert(1, "{index:0" + str(_n_hash) + "d}")
     assert scan.processed_file_naming_pattern == "".join(_parts)
 
 
@@ -178,9 +212,9 @@ def test_get_metadata_for_dim():
         _label = get_random_string(20)
         scan.set_param_value(f"scan_dim{_index}_unit", _unit)
         scan.set_param_value(f"scan_dim{_index}_label", _label)
-        _scanlabel, _scanunit, _range = scan.get_metadata_for_dim(_index)
-        assert _scanlabel == _label
-        assert _unit == _scanunit
+        _scan_label, _scan_unit, _range = scan.get_metadata_for_dim(_index)
+        assert _scan_label == _label
+        assert _unit == _scan_unit
         assert np.allclose(get_scan_range(_index), _range)
 
 
@@ -189,14 +223,9 @@ def test_get_indices_from_ordinal(n_frames):
     scan = Scan()
     set_scan_params(scan)
     scan.set_param_value("scan_frames_per_point", n_frames)
-    _pos = tuple(i - 2 for i in _scan_param_values["shape"])
-    _shape = _scan_param_values["shape"] + (1,)
-    _n = np.sum(
-        [
-            _pos[i] * np.prod(_shape[i + 1 :])
-            for i in range(_scan_param_values["scan_dim"])
-        ]
-    )
+    _pos = tuple(i - 2 for i in _SCAN_SHAPE)
+    _shape = _SCAN_SHAPE + (1,)
+    _n = np.sum([_pos[i] * np.prod(_shape[i + 1 :]) for i in range(_SCAN_DIM)])
     _index = scan.get_indices_from_ordinal(_n)
     assert _index == _pos
 
@@ -222,13 +251,13 @@ def test_get_ordinal_from_indices__negative():
         scan.get_ordinal_from_indices((0, -1, 0, 0))
 
 
-def test_get_ordinal_from_indices__inscan():
+def test_get_ordinal_from_indices__in_scan():
     _indices = (2, 1, 2, 1)
     _frame = (
         _indices[3]
-        + _scan_param_values["shape"][3] * _indices[2]
-        + np.prod(_scan_param_values["shape"][2:]) * _indices[1]
-        + np.prod(_scan_param_values["shape"][1:]) * _indices[0]
+        + _SCAN_SHAPE[3] * _indices[2]
+        + np.prod(_SCAN_SHAPE[2:]) * _indices[1]
+        + np.prod(_SCAN_SHAPE[1:]) * _indices[0]
     )
     scan = Scan()
     set_scan_params(scan)
@@ -239,8 +268,8 @@ def test_get_ordinal_from_indices__inscan():
 def test_axis_labels():
     scan = Scan()
     set_scan_params(scan)
-    _labels = [get_random_string(5) for _ in range(_scan_param_values["scan_dim"])]
-    for _index in range(_scan_param_values["scan_dim"]):
+    _labels = [get_random_string(5) for _ in range(_SCAN_DIM)]
+    for _index in range(_SCAN_DIM):
         scan.set_param_value(f"scan_dim{_index}_label", _labels[_index])
     assert _labels == scan.axis_labels
 
@@ -248,8 +277,8 @@ def test_axis_labels():
 def test_axis_units():
     scan = Scan()
     set_scan_params(scan)
-    _units = [get_random_string(5) for _ in range(_scan_param_values["scan_dim"])]
-    for _index in range(_scan_param_values["scan_dim"]):
+    _units = [get_random_string(5) for _ in range(_SCAN_DIM)]
+    for _index in range(_SCAN_DIM):
         scan.set_param_value(f"scan_dim{_index}_unit", _units[_index])
     assert _units == scan.axis_units
 
@@ -258,7 +287,7 @@ def test_axis_ranges():
     scan = Scan()
     set_scan_params(scan)
     _ranges = scan.axis_ranges
-    for _index in range(_scan_param_values["scan_dim"]):
+    for _index in range(_SCAN_DIM):
         _ref = get_scan_range(_index)
         assert np.allclose(_ref, _ranges[_index])
 
@@ -317,10 +346,9 @@ def test_update_from_dictionary__all_entries_present():
     assert scan.get_param_value("scan_title") == _scan["scan_title"]
     assert scan.get_param_value("scan_dim") == _scan["scan_dim"]
     for _dim in [0, 1]:
+        _dim_info: dict[str, str | int] = _scan[_dim]  # type: ignore[typeddict-unknown-key]
         for _entry in ["label", "unit", "offset", "delta", "n_points"]:
-            assert _scan[_dim][_entry] == scan.get_param_value(
-                f"scan_dim{_dim}_{_entry}"
-            )
+            assert _dim_info[_entry] == scan.get_param_value(f"scan_dim{_dim}_{_entry}")
 
 
 def test_set_param_value__deprecated():

--- a/tests/contexts/scan/test_scan.py
+++ b/tests/contexts/scan/test_scan.py
@@ -111,7 +111,7 @@ def test_squeezed_shape__default_scan():
     # Default scan_dim is 1, and scan_dim0_n_points should be 1
     _squeezed = scan.squeezed_shape
     assert isinstance(_squeezed, tuple)
-    # The result should be empty or contain only 1s removed
+    assert _squeezed == ()
 
 
 def test_ndim():

--- a/tests/workflow/result_io/test_processing_result_io_hdf5.py
+++ b/tests/workflow/result_io/test_processing_result_io_hdf5.py
@@ -141,7 +141,7 @@ def setup_module_data(temp_path):
     import_legacy_no_match_filename = temp_path / "import_test_legacy_no_match.h5"
 
     for _name, _dset, _extra_kwargs in [
-        (import_squeezed_filename, squeezed_data, {"squeezed_scan_dims": [1]}),
+        (import_squeezed_filename, squeezed_data, {"squeezed_scan_dims": "1"}),
         (import_squeezed_empty_filename, squeezed_data, {}),
         (import_legacy_squeezed_filename, squeezed_data, {}),
         (import_legacy_no_match_filename, mismatched_data, {}),
@@ -521,7 +521,10 @@ def test_update_metadata__with_squeeze(empty_temp_path):
     H5SAVER.update_metadata({1: _data}, scan=_scan, squeeze=True)
     _fname = empty_temp_path / H5SAVER._filenames[1]
     with h5py.File(_fname, "r") as _file:
-        _squeezed_dims = list(_file["entry/pydidas_config/squeezed_scan_dims"][()])
+        _squeeze_str = read_and_decode_hdf5_dataset(
+            _file["entry/pydidas_config/squeezed_scan_dims"]
+        )
+        _squeezed_dims = [int(_i) for _i in _squeeze_str.split(";")]
     assert _squeezed_dims == [1]
 
 
@@ -546,10 +549,12 @@ def test_export_full_data_to_file__with_squeeze(empty_temp_path):
     H5SAVER.export_full_data_to_file(_full_data, scan_context=_scan, squeeze=True)
     with h5py.File(empty_temp_path / H5SAVER._filenames[1], "r") as _file:
         _written = _file["entry/data/data"][()]
-        _squeezed_dims = list(_file["entry/pydidas_config/squeezed_scan_dims"][()])
+        _squeeze_str = read_and_decode_hdf5_dataset(
+            _file["entry/pydidas_config/squeezed_scan_dims"]
+        )
     assert _written.shape == _squeezed_shape
     assert np.allclose(_written, _full_data[1].squeeze().array)
-    assert _squeezed_dims == [1]
+    assert _squeeze_str == "1"
 
 
 def test_import_results_from_file__with_squeezed_dims_flag(setup_module_data):

--- a/tests/workflow/result_io/test_processing_result_io_hdf5.py
+++ b/tests/workflow/result_io/test_processing_result_io_hdf5.py
@@ -57,6 +57,23 @@ META = ProcessingResultIoMeta
 H5SAVER = ProcessingResultIoHdf5
 
 
+def _make_scan_with_size1_dims(n_dim: int, *size_1_dims: int) -> Scan:
+    _scan = Scan()
+    _default_shape = (3, 7, 5, 11)
+    _units = ("mm", "deg", "um", "rad")
+    _offsets = (0.5, -2, 11, 4.2)
+    _deltas = (0.1, -0.2, 0.4, 0.75)
+    _scan.set_param_value("scan_dim", n_dim)
+    for _dim in range(n_dim):
+        _scan.set_param_value(f"scan_dim{_dim}_label", f"motor{_dim}")
+        _size = 1 if _dim in size_1_dims else _default_shape[_dim]
+        _scan.set_param_value(f"scan_dim{_dim}_n_points", _size)
+        _scan.set_param_value(f"scan_dim{_dim}_delta", _deltas[_dim])
+        _scan.set_param_value(f"scan_dim{_dim}_offset", _offsets[_dim])
+        _scan.set_param_value(f"scan_dim{_dim}_unit", _units[_dim])
+    return _scan
+
+
 class TestProcessingResultIoHdf5(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -86,28 +103,6 @@ class TestProcessingResultIoHdf5(unittest.TestCase):
         shutil.rmtree(cls._dir)
 
     @classmethod
-    def _make_scan_with_size1_dim(cls) -> Scan:
-        """Return a Scan with dim0 having n_points=1 and dim1 having n_points=5."""
-        _scan = Scan()
-        _scan.set_param_value("scan_dim", 3)
-        _scan.set_param_value("scan_dim0_n_points", 3)
-        _scan.set_param_value("scan_dim0_delta", 1.0)
-        _scan.set_param_value("scan_dim0_offset", 0.5)
-        _scan.set_param_value("scan_dim0_label", "motor0")
-        _scan.set_param_value("scan_dim0_unit", "mm")
-        _scan.set_param_value("scan_dim1_n_points", 1)
-        _scan.set_param_value("scan_dim1_delta", 0.2)
-        _scan.set_param_value("scan_dim1_offset", 1.0)
-        _scan.set_param_value("scan_dim1_label", "motor1")
-        _scan.set_param_value("scan_dim1_unit", "deg")
-        _scan.set_param_value("scan_dim2_n_points", 7)
-        _scan.set_param_value("scan_dim2_delta", 0.5)
-        _scan.set_param_value("scan_dim2_offset", 1.0)
-        _scan.set_param_value("scan_dim2_label", "motor2")
-        _scan.set_param_value("scan_dim2_unit", "um")
-        return _scan
-
-    @classmethod
     def _create_h5_squeezed_test_files(cls):
         """
         Create HDF5 result files with squeezed scan data for import tests.
@@ -118,11 +113,13 @@ class TestProcessingResultIoHdf5(unittest.TestCase):
         - import_test_legacy_squeezed.h5   : no ``squeezed_scan_dims`` key (legacy)
         - import_test_legacy_no_match.h5   : no ``squeezed_scan_dims`` key, shape mismatch
         """
-        _scan = cls._make_scan_with_size1_dim()  # shape (3, 1, 7)
+        cls._data_shape = (5, 7)
+        cls._mismatched_data_shape = (2, 3, 4, 5)
+        _scan = _make_scan_with_size1_dims(3, 1)
         _data = cls._squeezed_import_data = create_dataset(
-            5, shape=_scan.shape + (5, 7)
+            5, shape=_scan.shape + cls._data_shape
         ).squeeze()
-        _mismatched_data = create_dataset(4, shape=(2, 3, 4, 5))
+        _mismatched_data = create_dataset(4, shape=cls._mismatched_data_shape)
 
         _scan_dict = _scan.get_param_values_as_dict(filter_types_for_export=True)
         _exp_dict = EXP.get_param_values_as_dict(filter_types_for_export=True)
@@ -397,21 +394,30 @@ class TestProcessingResultIoHdf5(unittest.TestCase):
             )
 
     def test_insert_squeezed_scan_dims__single_dim(self):
-        _scan = self._make_scan_with_size1_dim()
+        _scan = _make_scan_with_size1_dims(3, 1)
         _data = Dataset(
-            np.random.random((3, 7, 12)),
+            np.random.random(_scan.squeezed_shape + self._data_shape),
             axis_labels={
-                0: _scan.axis_labels[0], 1: _scan.axis_labels[2], 2: "data_label"
+                0: _scan.axis_labels[0],
+                1: _scan.axis_labels[2],
+                2: "data_label0",
+                3: "data_label1",
             },
-            axis_units={0: _scan.axis_units[0], 1: _scan.axis_units[2], 2: "data_unit"},
+            axis_units={
+                0: _scan.axis_units[0],
+                1: _scan.axis_units[2],
+                2: "data_unit",
+                3: "data_unit B",
+            },
             axis_ranges={
                 0: _scan.axis_ranges[0],
                 1: _scan.axis_ranges[2],
-                2: np.linspace(11, 12, 12),
+                2: np.linspace(11, 12, self._data_shape[0]),
+                3: np.linspace(0, 2, self._data_shape[1]),
             },
         )
         _result = H5SAVER._insert_squeezed_scan_dims(_data, _scan, [1])
-        self.assertEqual(_result.shape, (3, 1, 7, 12))
+        self.assertEqual(_result.shape, _scan.shape + self._data_shape)
         for _dim in [0, 1, 2]:
             self.assertEqual(
                 _result.axis_labels[_dim],
@@ -420,78 +426,43 @@ class TestProcessingResultIoHdf5(unittest.TestCase):
             self.assertEqual(
                 _result.axis_units[_dim], _scan.get_param_value(f"scan_dim{_dim}_unit")
             )
+        self.assertTrue(np.allclose(_result.squeeze(), _data))
 
     def test_insert_squeezed_scan_dims__multiple_dims(self):
-        # 3D scan with size-1 dims at indices 0 and 2
-        _scan = Scan()
-        _scan.set_param_value("scan_dim", 3)
-        _scan.set_param_value("scan_dim0_n_points", 1)
-        _scan.set_param_value("scan_dim0_delta", 1.0)
-        _scan.set_param_value("scan_dim0_offset", 0.0)
-        _scan.set_param_value("scan_dim0_label", "motor0")
-        _scan.set_param_value("scan_dim0_unit", "mm")
-        _scan.set_param_value("scan_dim1_n_points", 5)
-        _scan.set_param_value("scan_dim1_delta", 0.1)
-        _scan.set_param_value("scan_dim1_offset", 0.0)
-        _scan.set_param_value("scan_dim1_label", "motor1")
-        _scan.set_param_value("scan_dim1_unit", "deg")
-        _scan.set_param_value("scan_dim2_n_points", 1)
-        _scan.set_param_value("scan_dim2_delta", 1.0)
-        _scan.set_param_value("scan_dim2_offset", 0.0)
-        _scan.set_param_value("scan_dim2_label", "motor2")
-        _scan.set_param_value("scan_dim2_unit", "um")
-        # Squeezed data has shape (5, 12): only scan dim1 + plugin dim
+        _scan = _make_scan_with_size1_dims(3, 0, 2)
+        _data_shape = (12,)
         _data = Dataset(
-            np.random.random((5, 12)),
+            np.random.random(_scan.squeezed_shape + _data_shape),
             axis_labels={0: "motor1_ax", 1: "intensity"},
             axis_units={0: "deg", 1: "a.u."},
-            axis_ranges={0: np.linspace(0, 0.4, 5), 1: np.arange(12, dtype=float)},
-        )
-        _result = H5SAVER._insert_squeezed_scan_dims(_data, _scan, [0, 2])
-        # Expected shape: (1, 5, 1, 12) — dim0 and dim2 re-inserted
-        self.assertEqual(_result.shape, (1, 5, 1, 12))
-        self.assertEqual(_result.axis_labels[0], "motor0")
-        self.assertEqual(_result.axis_labels[1], "motor1_ax")
-        self.assertEqual(_result.axis_labels[2], "motor2")
-        self.assertEqual(_result.axis_labels[3], "intensity")
-
-    def test_insert_squeezed_scan_dims__values_preserved(self):
-        # scan shape (3, 1, 7) — dim1 is size-1; squeezed data has shape (3, 7, 8)
-        _scan = self._make_scan_with_size1_dim()
-        _original = np.random.random((3, 7, 8))
-        _data = Dataset(
-            _original,
-            axis_labels={0: "ax0", 1: "ax1", 2: "ax2"},
-            axis_units={0: "u0", 1: "u1", 2: "u2"},
             axis_ranges={
-                0: np.linspace(0.5, 2.5, 3),
-                1: np.linspace(1.0, 4.0, 7),
-                2: np.arange(8, dtype=float),
+                0: np.linspace(0, 0.4, _scan.shape[1]),
+                1: np.arange(_data_shape[0], dtype=float),
             },
         )
-        _result = H5SAVER._insert_squeezed_scan_dims(_data, _scan, [1])
-        self.assertTrue(np.allclose(_result.squeeze(), _original))
-
-    # ------------------------------------------------------------------
-    # Tests for update_metadata with squeeze=True
-    # ------------------------------------------------------------------
+        _result = H5SAVER._insert_squeezed_scan_dims(_data, _scan, [0, 2])
+        self.assertEqual(_result.shape, _scan.shape + _data_shape)
+        self.assertEqual(_result.axis_labels[0], _scan.axis_labels[0])
+        self.assertEqual(_result.axis_labels[1], _data.axis_labels[0])
+        self.assertEqual(_result.axis_labels[2], _scan.axis_labels[2])
+        self.assertEqual(_result.axis_labels[3], _data.axis_labels[1])
+        self.assertTrue(np.allclose(_result.squeeze(), _data))
 
     def test_update_metadata__with_squeeze(self):
-        _scan = self._make_scan_with_size1_dim()  # shape (3, 1, 7); dim1 is size-1
+        _scan = _make_scan_with_size1_dims(3, 1)
         _plugin_shape = (12, 7)
-        _full_shape = _scan.shape + _plugin_shape  # (3, 1, 7, 12, 7)
+        _full_shape = _scan.shape + _plugin_shape
         _node_infos = {
             1: {
                 "node_label": "SqueezedNode",
                 "data_label": "Intensity",
                 "data_unit": "a.u.",
-                "shape": _plugin_shape,  # plugin output dims only (no scan dims yet)
+                "shape": _plugin_shape,
                 "plugin_name": "SomeProcPlugin",
             }
         }
         _resdir = self._dir / get_random_string(8)
         H5SAVER.prepare_files_and_directories(_resdir, _node_infos, scan_context=_scan)
-        # Build a full Dataset (scan dims + plugin dims) for metadata extraction
         _data = Dataset(
             np.random.random(_full_shape),
             axis_labels={i: f"ax{i}" for i in range(len(_full_shape))},
@@ -507,16 +478,11 @@ class TestProcessingResultIoHdf5(unittest.TestCase):
             _squeezed_dims = list(_file["entry/pydidas_config/squeezed_scan_dims"][()])
         self.assertEqual(_squeezed_dims, [1])
 
-    # ------------------------------------------------------------------
-    # Tests for export_full_data_to_file with squeeze=True
-    # ------------------------------------------------------------------
-
     def test_export_full_data_to_file__with_squeeze(self):
-        _scan = self._make_scan_with_size1_dim()  # shape (3, 1, 7); dim1 is size-1
+        _scan = _make_scan_with_size1_dims(3, 1)
         _plugin_shape = (12, 7)
-        _full_shape = _scan.shape + _plugin_shape  # (3, 1, 7, 12, 7)
-        _squeezed_shape = (3, 7) + _plugin_shape  # (3, 7, 12, 7)
-        # Pre-allocate with the squeezed shape so the squeezed write fits
+        _full_shape = _scan.shape + _plugin_shape
+        _squeezed_shape = _scan.squeezed_shape + _plugin_shape
         _node_infos = {
             1: {
                 "node_label": "SqueezedNode",
@@ -530,58 +496,48 @@ class TestProcessingResultIoHdf5(unittest.TestCase):
         H5SAVER.prepare_files_and_directories(_resdir, _node_infos, scan_context=_scan)
         _full_data = {1: Dataset(np.random.random(_full_shape))}
         H5SAVER.export_full_data_to_file(_full_data, scan_context=_scan, squeeze=True)
-        _fname = _resdir / H5SAVER._filenames[1]
-        with h5py.File(_fname, "r") as _file:
+        with h5py.File(_resdir / H5SAVER._filenames[1], "r") as _file:
             _written = _file["entry/data/data"][()]
             _squeezed_dims = list(_file["entry/pydidas_config/squeezed_scan_dims"][()])
         self.assertEqual(_written.shape, _squeezed_shape)
         self.assertTrue(np.allclose(_written, _full_data[1].squeeze().array))
         self.assertEqual(_squeezed_dims, [1])
 
-    # ------------------------------------------------------------------
-    # Tests for import_results_from_file with squeezed dims
-    # ------------------------------------------------------------------
-
     def test_import_results_from_file__with_squeezed_dims_flag(self):
-        # Squeezed data stored as (3, 7, 5, 7); after import: (3, 1, 7, 5, 7).
+        """Test to check that data was re-inserted for squeezed dim"""
         _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
             self._import_squeezed_filename
         )
-        self.assertEqual(_data.shape, (3, 1, 7, 5, 7))
-        # The re-inserted dim gets its metadata from the scan
-        self.assertEqual(_data.axis_labels[1], "motor1")
-        self.assertEqual(_data.axis_units[1], "deg")
-        # The axis that was at position 0 in the squeezed data stays at position 0
+        self.assertEqual(_data.shape, _scan.shape + self._data_shape)
+        self.assertEqual(_data.axis_labels[1], _scan.axis_labels[1])
+        self.assertEqual(_data.axis_units[1], _scan.axis_units[1])
         self.assertEqual(
             _data.axis_labels[0], self._squeezed_import_data.axis_labels[0]
         )
 
     def test_import_results_from_file__with_empty_squeezed_dims_flag(self):
-        # File has squeezed_scan_dims=[] (empty); no re-insertion expected.
-        # Squeezed data was stored as (3, 7, 5, 7); shape must stay the same.
+        """Test to check that no data was re-inserted for squeezed dim"""
         _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
             self._import_squeezed_empty_filename
         )
-        self.assertEqual(_data.shape, (3, 7, 5, 7))
+        _expected_shape = _scan.squeezed_shape + self._data_shape
+        self.assertEqual(_data.shape, _expected_shape)
 
     def test_import_results_from_file__legacy_squeezed_dims(self):
-        # Legacy file has no squeezed_scan_dims key.
-        # scan has dim1 with n_points=1; _scan_shape_no_ones=(3, 7).
-        # Stored data shape (3, 7, 5, 7) starts with (3, 7) → backward compat re-inserts dim1.
+        """Test to check that data was re-inserted if key is misssing"""
         _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
             self._import_legacy_squeezed_filename
         )
-        self.assertEqual(_data.shape, (3, 1, 7, 5, 7))
-        self.assertEqual(_data.axis_labels[1], "motor1")
-        self.assertEqual(_data.axis_units[1], "deg")
+        self.assertEqual(_data.shape, _scan.shape + self._data_shape)
+        self.assertEqual(_data.axis_labels[1], _scan.axis_labels[1])
+        self.assertEqual(_data.axis_units[1], _scan.axis_units[1])
 
     def test_import_results_from_file__legacy_size1_dims_shape_no_match(self):
-        # Legacy file: scan has size-1 dim0, but data shape (3, 27) does NOT
-        # match the non-size-1 scan prefix (5,) → no re-insertion.
+        """Without key and shape mismatch, data should stay the same"""
         _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
             self._import_legacy_no_match_filename
         )
-        self.assertEqual(_data.shape, (2, 3, 4, 5))
+        self.assertEqual(_data.shape, self._mismatched_data_shape)
 
 
 if __name__ == "__main__":

--- a/tests/workflow/result_io/test_processing_result_io_hdf5.py
+++ b/tests/workflow/result_io/test_processing_result_io_hdf5.py
@@ -34,11 +34,16 @@ from pathlib import Path
 import h5py
 import numpy as np
 
-from pydidas.contexts import DiffractionExperimentContext, ScanContext
+from pydidas.contexts import (
+    DiffractionExperimentContext,
+    Scan,
+    ScanContext,
+)
 from pydidas.core import Dataset, UserConfigError
 from pydidas.core.utils import get_random_string
 from pydidas.core.utils.hdf5 import read_and_decode_hdf5_dataset
 from pydidas.unittest_objects import create_hdf5_results_file
+from pydidas.unittest_objects.create_dataset_ import create_dataset
 from pydidas.workflow import ProcessingResults, WorkflowTree
 from pydidas.workflow.result_io import ProcessingResultIoMeta
 from pydidas.workflow.result_io.processing_result_io_hdf5 import ProcessingResultIoHdf5
@@ -57,7 +62,7 @@ class TestProcessingResultIoHdf5(unittest.TestCase):
     def setUpClass(cls):
         cls._dir = Path(tempfile.mkdtemp())
         SCAN.restore_all_defaults(confirm=True)
-        SCAN.set_param_value("scan_dim", 2)
+        SCAN.set_param_value("scan_dim", 3)
         for d in range(4):
             SCAN.set_param_value(f"scan_dim{d}_n_points", random.choice([3, 5, 7, 8]))
             SCAN.set_param_value(
@@ -74,10 +79,88 @@ class TestProcessingResultIoHdf5(unittest.TestCase):
             elif EXP.params[_key].dtype == str:
                 EXP.set_param_value(_key, get_random_string(12))
         cls._create_h5_test_file()
+        cls._create_h5_squeezed_test_files()
 
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls._dir)
+
+    @classmethod
+    def _make_scan_with_size1_dim(cls) -> Scan:
+        """Return a Scan with dim0 having n_points=1 and dim1 having n_points=5."""
+        _scan = Scan()
+        _scan.set_param_value("scan_dim", 3)
+        _scan.set_param_value("scan_dim0_n_points", 3)
+        _scan.set_param_value("scan_dim0_delta", 1.0)
+        _scan.set_param_value("scan_dim0_offset", 0.5)
+        _scan.set_param_value("scan_dim0_label", "motor0")
+        _scan.set_param_value("scan_dim0_unit", "mm")
+        _scan.set_param_value("scan_dim1_n_points", 1)
+        _scan.set_param_value("scan_dim1_delta", 0.2)
+        _scan.set_param_value("scan_dim1_offset", 1.0)
+        _scan.set_param_value("scan_dim1_label", "motor1")
+        _scan.set_param_value("scan_dim1_unit", "deg")
+        _scan.set_param_value("scan_dim2_n_points", 7)
+        _scan.set_param_value("scan_dim2_delta", 0.5)
+        _scan.set_param_value("scan_dim2_offset", 1.0)
+        _scan.set_param_value("scan_dim2_label", "motor2")
+        _scan.set_param_value("scan_dim2_unit", "um")
+        return _scan
+
+    @classmethod
+    def _create_h5_squeezed_test_files(cls):
+        """
+        Create HDF5 result files with squeezed scan data for import tests.
+
+        Four files are created:
+        - import_test_squeezed.h5          : ``squeezed_scan_dims = [1]``
+        - import_test_squeezed_empty.h5    : ``squeezed_scan_dims = []``
+        - import_test_legacy_squeezed.h5   : no ``squeezed_scan_dims`` key (legacy)
+        - import_test_legacy_no_match.h5   : no ``squeezed_scan_dims`` key, shape mismatch
+        """
+        _scan = cls._make_scan_with_size1_dim()  # shape (3, 1, 7)
+        _data = cls._squeezed_import_data = create_dataset(
+            5, shape=_scan.shape + (5, 7)
+        ).squeeze()
+        _mismatched_data = create_dataset(4, shape=(2, 3, 4, 5))
+
+        _scan_dict = _scan.get_param_values_as_dict(filter_types_for_export=True)
+        _exp_dict = EXP.get_param_values_as_dict(filter_types_for_export=True)
+
+        cls._import_squeezed_filename = cls._dir / "import_test_squeezed.h5"
+        cls._import_squeezed_empty_filename = cls._dir / "import_test_squeezed_empty.h5"
+        cls._import_legacy_squeezed_filename = (
+            cls._dir / "import_test_legacy_squeezed.h5"
+        )
+        cls._import_legacy_no_match_filename = (
+            cls._dir / "import_test_legacy_no_match.h5"
+        )
+        for _name, _dset, _extra_kwargs in [
+            # New-style file: squeezed_scan_dims=[1] written via the kwarg:
+            (cls._import_squeezed_filename, _data, {"squeezed_scan_dims": [1]}),
+            # New-style file: squeezed_scan_dims=[] (default — nothing was squeezed)
+            (cls._import_squeezed_empty_filename, _data, {}),
+            # Legacy file: delete squeezed_scan_dims to simulate a file written by an
+            # older pydidas version that never wrote the key.
+            (cls._import_legacy_squeezed_filename, _data, {}),
+            # Legacy file: no squeezed_scan_dims key; data shape does NOT match (no squeeze).
+            (cls._import_legacy_no_match_filename, _mismatched_data, {}),
+        ]:
+            create_hdf5_results_file(
+                _name,
+                _dset,
+                _scan_dict,
+                _exp_dict,
+                TREE,
+                node_label="Label",
+                plugin_name="SomePlugin",
+                **_extra_kwargs,
+            )
+
+        with h5py.File(cls._import_legacy_squeezed_filename, "r+") as _file:
+            del _file["entry/pydidas_config/squeezed_scan_dims"]
+        with h5py.File(cls._import_legacy_no_match_filename, "r+") as _file:
+            del _file["entry/pydidas_config/squeezed_scan_dims"]
 
     @classmethod
     def _create_h5_test_file(cls):
@@ -140,24 +223,9 @@ class TestProcessingResultIoHdf5(unittest.TestCase):
 
     def get_datasets(self, start_dim=3):
         return {
-            _key: Dataset(np.random.random(_shape[start_dim:]))
+            _key: create_dataset(len(_shape[start_dim:]), shape=_shape[start_dim:])
             for _key, _shape in self._shapes.items()
         }
-
-    def populate_metadata(self, dataset):
-        _labels = {_key: get_random_string(8) for _key in dataset.axis_labels}
-        _units = {_key: get_random_string(3) for _key in dataset.axis_units}
-        _ranges = {
-            _key: random.random() * np.arange(_len) + random.random()
-            for _key, _len in enumerate(dataset.shape)
-        }
-        dataset.data_label = get_random_string(12)
-        dataset.data_unit = get_random_string(3)
-        for _axis in _labels:
-            dataset.update_axis_label(_axis, _labels[_axis])
-            dataset.update_axis_unit(_axis, _units[_axis])
-            dataset.update_axis_range(_axis, _ranges[_axis])
-        return dataset, _labels, _units, _ranges
 
     def assert_written_files_are_okay(self, data, metadata):
         for _node_id in self._shapes:
@@ -211,9 +279,6 @@ class TestProcessingResultIoHdf5(unittest.TestCase):
     def test_update_with_scan_metadata(self):
         self.prepare_with_defaults()
         _datasets = self.get_datasets()
-        for _key, _dataset in _datasets.items():
-            _dataset, _, _, _ = self.populate_metadata(_dataset)
-            _datasets[_key] = _dataset
         _metadata = H5SAVER.update_with_scan_metadata(_datasets, SCAN)
         for _key, _metadata in _metadata.items():
             self.assertEqual(_metadata["data_label"], _datasets[_key].data_label)
@@ -243,11 +308,9 @@ class TestProcessingResultIoHdf5(unittest.TestCase):
     def test_update_metadata__standard(self):
         self.prepare_with_defaults()
         _data = {
-            _key: Dataset(np.random.random(_shape[3:]))
+            _key: create_dataset(len(_shape[3:]), shape=_shape[3:])
             for _key, _shape in self._shapes.items()
         }
-        for _key in _data:
-            _data[_key], _, _, _ = self.populate_metadata(_data[_key])
         _metadata = {
             _key: dict(
                 axis_units=_item.axis_units,
@@ -332,6 +395,193 @@ class TestProcessingResultIoHdf5(unittest.TestCase):
             _data, _node_info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
                 _new_name
             )
+
+    def test_insert_squeezed_scan_dims__single_dim(self):
+        _scan = self._make_scan_with_size1_dim()
+        _data = Dataset(
+            np.random.random((3, 7, 12)),
+            axis_labels={
+                0: _scan.axis_labels[0], 1: _scan.axis_labels[2], 2: "data_label"
+            },
+            axis_units={0: _scan.axis_units[0], 1: _scan.axis_units[2], 2: "data_unit"},
+            axis_ranges={
+                0: _scan.axis_ranges[0],
+                1: _scan.axis_ranges[2],
+                2: np.linspace(11, 12, 12),
+            },
+        )
+        _result = H5SAVER._insert_squeezed_scan_dims(_data, _scan, [1])
+        self.assertEqual(_result.shape, (3, 1, 7, 12))
+        for _dim in [0, 1, 2]:
+            self.assertEqual(
+                _result.axis_labels[_dim],
+                _scan.get_param_value(f"scan_dim{_dim}_label"),
+            )
+            self.assertEqual(
+                _result.axis_units[_dim], _scan.get_param_value(f"scan_dim{_dim}_unit")
+            )
+
+    def test_insert_squeezed_scan_dims__multiple_dims(self):
+        # 3D scan with size-1 dims at indices 0 and 2
+        _scan = Scan()
+        _scan.set_param_value("scan_dim", 3)
+        _scan.set_param_value("scan_dim0_n_points", 1)
+        _scan.set_param_value("scan_dim0_delta", 1.0)
+        _scan.set_param_value("scan_dim0_offset", 0.0)
+        _scan.set_param_value("scan_dim0_label", "motor0")
+        _scan.set_param_value("scan_dim0_unit", "mm")
+        _scan.set_param_value("scan_dim1_n_points", 5)
+        _scan.set_param_value("scan_dim1_delta", 0.1)
+        _scan.set_param_value("scan_dim1_offset", 0.0)
+        _scan.set_param_value("scan_dim1_label", "motor1")
+        _scan.set_param_value("scan_dim1_unit", "deg")
+        _scan.set_param_value("scan_dim2_n_points", 1)
+        _scan.set_param_value("scan_dim2_delta", 1.0)
+        _scan.set_param_value("scan_dim2_offset", 0.0)
+        _scan.set_param_value("scan_dim2_label", "motor2")
+        _scan.set_param_value("scan_dim2_unit", "um")
+        # Squeezed data has shape (5, 12): only scan dim1 + plugin dim
+        _data = Dataset(
+            np.random.random((5, 12)),
+            axis_labels={0: "motor1_ax", 1: "intensity"},
+            axis_units={0: "deg", 1: "a.u."},
+            axis_ranges={0: np.linspace(0, 0.4, 5), 1: np.arange(12, dtype=float)},
+        )
+        _result = H5SAVER._insert_squeezed_scan_dims(_data, _scan, [0, 2])
+        # Expected shape: (1, 5, 1, 12) — dim0 and dim2 re-inserted
+        self.assertEqual(_result.shape, (1, 5, 1, 12))
+        self.assertEqual(_result.axis_labels[0], "motor0")
+        self.assertEqual(_result.axis_labels[1], "motor1_ax")
+        self.assertEqual(_result.axis_labels[2], "motor2")
+        self.assertEqual(_result.axis_labels[3], "intensity")
+
+    def test_insert_squeezed_scan_dims__values_preserved(self):
+        # scan shape (3, 1, 7) — dim1 is size-1; squeezed data has shape (3, 7, 8)
+        _scan = self._make_scan_with_size1_dim()
+        _original = np.random.random((3, 7, 8))
+        _data = Dataset(
+            _original,
+            axis_labels={0: "ax0", 1: "ax1", 2: "ax2"},
+            axis_units={0: "u0", 1: "u1", 2: "u2"},
+            axis_ranges={
+                0: np.linspace(0.5, 2.5, 3),
+                1: np.linspace(1.0, 4.0, 7),
+                2: np.arange(8, dtype=float),
+            },
+        )
+        _result = H5SAVER._insert_squeezed_scan_dims(_data, _scan, [1])
+        self.assertTrue(np.allclose(_result.squeeze(), _original))
+
+    # ------------------------------------------------------------------
+    # Tests for update_metadata with squeeze=True
+    # ------------------------------------------------------------------
+
+    def test_update_metadata__with_squeeze(self):
+        _scan = self._make_scan_with_size1_dim()  # shape (3, 1, 7); dim1 is size-1
+        _plugin_shape = (12, 7)
+        _full_shape = _scan.shape + _plugin_shape  # (3, 1, 7, 12, 7)
+        _node_infos = {
+            1: {
+                "node_label": "SqueezedNode",
+                "data_label": "Intensity",
+                "data_unit": "a.u.",
+                "shape": _plugin_shape,  # plugin output dims only (no scan dims yet)
+                "plugin_name": "SomeProcPlugin",
+            }
+        }
+        _resdir = self._dir / get_random_string(8)
+        H5SAVER.prepare_files_and_directories(_resdir, _node_infos, scan_context=_scan)
+        # Build a full Dataset (scan dims + plugin dims) for metadata extraction
+        _data = Dataset(
+            np.random.random(_full_shape),
+            axis_labels={i: f"ax{i}" for i in range(len(_full_shape))},
+            axis_units={i: f"u{i}" for i in range(len(_full_shape))},
+            axis_ranges={
+                i: np.arange(_full_shape[i], dtype=float)
+                for i in range(len(_full_shape))
+            },
+        )
+        H5SAVER.update_metadata({1: _data}, scan=_scan, squeeze=True)
+        _fname = _resdir / H5SAVER._filenames[1]
+        with h5py.File(_fname, "r") as _file:
+            _squeezed_dims = list(_file["entry/pydidas_config/squeezed_scan_dims"][()])
+        self.assertEqual(_squeezed_dims, [1])
+
+    # ------------------------------------------------------------------
+    # Tests for export_full_data_to_file with squeeze=True
+    # ------------------------------------------------------------------
+
+    def test_export_full_data_to_file__with_squeeze(self):
+        _scan = self._make_scan_with_size1_dim()  # shape (3, 1, 7); dim1 is size-1
+        _plugin_shape = (12, 7)
+        _full_shape = _scan.shape + _plugin_shape  # (3, 1, 7, 12, 7)
+        _squeezed_shape = (3, 7) + _plugin_shape  # (3, 7, 12, 7)
+        # Pre-allocate with the squeezed shape so the squeezed write fits
+        _node_infos = {
+            1: {
+                "node_label": "SqueezedNode",
+                "data_label": "Intensity",
+                "data_unit": "a.u.",
+                "shape": _squeezed_shape,
+                "plugin_name": "SomeProcPlugin",
+            }
+        }
+        _resdir = self._dir / get_random_string(8)
+        H5SAVER.prepare_files_and_directories(_resdir, _node_infos, scan_context=_scan)
+        _full_data = {1: Dataset(np.random.random(_full_shape))}
+        H5SAVER.export_full_data_to_file(_full_data, scan_context=_scan, squeeze=True)
+        _fname = _resdir / H5SAVER._filenames[1]
+        with h5py.File(_fname, "r") as _file:
+            _written = _file["entry/data/data"][()]
+            _squeezed_dims = list(_file["entry/pydidas_config/squeezed_scan_dims"][()])
+        self.assertEqual(_written.shape, _squeezed_shape)
+        self.assertTrue(np.allclose(_written, _full_data[1].squeeze().array))
+        self.assertEqual(_squeezed_dims, [1])
+
+    # ------------------------------------------------------------------
+    # Tests for import_results_from_file with squeezed dims
+    # ------------------------------------------------------------------
+
+    def test_import_results_from_file__with_squeezed_dims_flag(self):
+        # Squeezed data stored as (3, 7, 5, 7); after import: (3, 1, 7, 5, 7).
+        _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
+            self._import_squeezed_filename
+        )
+        self.assertEqual(_data.shape, (3, 1, 7, 5, 7))
+        # The re-inserted dim gets its metadata from the scan
+        self.assertEqual(_data.axis_labels[1], "motor1")
+        self.assertEqual(_data.axis_units[1], "deg")
+        # The axis that was at position 0 in the squeezed data stays at position 0
+        self.assertEqual(
+            _data.axis_labels[0], self._squeezed_import_data.axis_labels[0]
+        )
+
+    def test_import_results_from_file__with_empty_squeezed_dims_flag(self):
+        # File has squeezed_scan_dims=[] (empty); no re-insertion expected.
+        # Squeezed data was stored as (3, 7, 5, 7); shape must stay the same.
+        _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
+            self._import_squeezed_empty_filename
+        )
+        self.assertEqual(_data.shape, (3, 7, 5, 7))
+
+    def test_import_results_from_file__legacy_squeezed_dims(self):
+        # Legacy file has no squeezed_scan_dims key.
+        # scan has dim1 with n_points=1; _scan_shape_no_ones=(3, 7).
+        # Stored data shape (3, 7, 5, 7) starts with (3, 7) → backward compat re-inserts dim1.
+        _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
+            self._import_legacy_squeezed_filename
+        )
+        self.assertEqual(_data.shape, (3, 1, 7, 5, 7))
+        self.assertEqual(_data.axis_labels[1], "motor1")
+        self.assertEqual(_data.axis_units[1], "deg")
+
+    def test_import_results_from_file__legacy_size1_dims_shape_no_match(self):
+        # Legacy file: scan has size-1 dim0, but data shape (3, 27) does NOT
+        # match the non-size-1 scan prefix (5,) → no re-insertion.
+        _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
+            self._import_legacy_no_match_filename
+        )
+        self.assertEqual(_data.shape, (2, 3, 4, 5))
 
 
 if __name__ == "__main__":

--- a/tests/workflow/result_io/test_processing_result_io_hdf5.py
+++ b/tests/workflow/result_io/test_processing_result_io_hdf5.py
@@ -26,13 +26,12 @@ __status__ = "Production"
 
 import random
 import shutil
-import tempfile
-import unittest
 from numbers import Integral, Real
 from pathlib import Path
 
 import h5py
 import numpy as np
+import pytest
 
 from pydidas.contexts import (
     DiffractionExperimentContext,
@@ -74,471 +73,522 @@ def _make_scan_with_size1_dims(n_dim: int, *size_1_dims: int) -> Scan:
     return _scan
 
 
-class TestProcessingResultIoHdf5(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls._dir = Path(tempfile.mkdtemp())
-        SCAN.restore_all_defaults(confirm=True)
-        SCAN.set_param_value("scan_dim", 3)
-        for d in range(4):
-            SCAN.set_param_value(f"scan_dim{d}_n_points", random.choice([3, 5, 7, 8]))
-            SCAN.set_param_value(
-                f"scan_dim{d}_delta", random.choice([0.1, 0.5, 1, 1.5])
-            )
-            SCAN.set_param_value(f"scan_dim{d}_offset", random.choice([-0.1, 0.5, 1]))
-            SCAN.set_param_value(f"scan_dim{d}_label", get_random_string(12))
-            SCAN.set_param_value(f"scan_dim{d}_unit", get_random_string(3))
-        for _key in EXP.params:
-            if EXP.params[_key].dtype == Integral:
-                EXP.set_param_value(_key, int(100 * np.random.random()))
-            elif EXP.params[_key].dtype == Real:
-                EXP.set_param_value(_key, np.random.random())
-            elif EXP.params[_key].dtype == str:
-                EXP.set_param_value(_key, get_random_string(12))
-        cls._create_h5_test_file()
-        cls._create_h5_squeezed_test_files()
+@pytest.fixture(scope="module")
+def setup_module_data(temp_path):
+    """
+    Module-level fixture to set up test data.
 
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls._dir)
+    This fixture:
+    1. Initializes SCAN and EXP contexts with random parameters
+    2. Creates test files for import tests
+    """
+    SCAN.restore_all_defaults(confirm=True)
+    SCAN.set_param_value("scan_dim", 3)
+    for d in range(4):
+        SCAN.set_param_value(f"scan_dim{d}_n_points", random.choice([3, 5, 7, 8]))
+        SCAN.set_param_value(f"scan_dim{d}_delta", random.choice([0.1, 0.5, 1, 1.5]))
+        SCAN.set_param_value(f"scan_dim{d}_offset", random.choice([-0.1, 0.5, 1]))
+        SCAN.set_param_value(f"scan_dim{d}_label", get_random_string(12))
+        SCAN.set_param_value(f"scan_dim{d}_unit", get_random_string(3))
 
-    @classmethod
-    def _create_h5_squeezed_test_files(cls):
-        """
-        Create HDF5 result files with squeezed scan data for import tests.
+    for _key in EXP.params:
+        if EXP.params[_key].dtype == Integral:
+            EXP.set_param_value(_key, int(100 * np.random.random()))
+        elif EXP.params[_key].dtype == Real:
+            EXP.set_param_value(_key, np.random.random())
+        elif EXP.params[_key].dtype == str:
+            EXP.set_param_value(_key, get_random_string(12))
 
-        Four files are created:
-        - import_test_squeezed.h5          : ``squeezed_scan_dims = [1]``
-        - import_test_squeezed_empty.h5    : ``squeezed_scan_dims = []``
-        - import_test_legacy_squeezed.h5   : no ``squeezed_scan_dims`` key (legacy)
-        - import_test_legacy_no_match.h5   : no ``squeezed_scan_dims`` key, shape mismatch
-        """
-        cls._data_shape = (5, 7)
-        cls._mismatched_data_shape = (2, 3, 4, 5)
-        _scan = _make_scan_with_size1_dims(3, 1)
-        _data = cls._squeezed_import_data = create_dataset(
-            5, shape=_scan.shape + cls._data_shape
-        ).squeeze()
-        _mismatched_data = create_dataset(4, shape=cls._mismatched_data_shape)
+    # Create basic import test file
+    import_test_filename = temp_path / "import_test.h5"
+    data = Dataset(
+        np.random.random((9, 9, 27)),
+        data_label=get_random_string(12),
+        data_unit=get_random_string(3),
+        axis_labels={0: "None", 1: None, 2: "Label"},
+        axis_units={0: "u1", 1: "u2", 2: None},
+        axis_ranges={
+            0: np.arange(9),
+            1: np.arange(9) - 3,
+            2: np.linspace(12, -5, num=27),
+        },
+    )
+    io_node_label = get_random_string(9)
+    import_plugin_name = get_random_string(8)
+    create_hdf5_results_file(
+        import_test_filename,
+        data,
+        SCAN.get_param_values_as_dict(filter_types_for_export=True),
+        EXP.get_param_values_as_dict(filter_types_for_export=True),
+        TREE,
+        node_label=io_node_label,
+        plugin_name=import_plugin_name,
+    )
 
-        _scan_dict = _scan.get_param_values_as_dict(filter_types_for_export=True)
-        _exp_dict = EXP.get_param_values_as_dict(filter_types_for_export=True)
+    # Create squeezed test files
+    data_shape = (5, 7)
+    mismatched_data_shape = (2, 3, 4, 5)
+    scan = _make_scan_with_size1_dims(3, 1)
+    squeezed_data = create_dataset(5, shape=scan.shape + data_shape).squeeze()
+    mismatched_data = create_dataset(4, shape=mismatched_data_shape)
 
-        cls._import_squeezed_filename = cls._dir / "import_test_squeezed.h5"
-        cls._import_squeezed_empty_filename = cls._dir / "import_test_squeezed_empty.h5"
-        cls._import_legacy_squeezed_filename = (
-            cls._dir / "import_test_legacy_squeezed.h5"
-        )
-        cls._import_legacy_no_match_filename = (
-            cls._dir / "import_test_legacy_no_match.h5"
-        )
-        for _name, _dset, _extra_kwargs in [
-            # New-style file: squeezed_scan_dims=[1] written via the kwarg:
-            (cls._import_squeezed_filename, _data, {"squeezed_scan_dims": [1]}),
-            # New-style file: squeezed_scan_dims=[] (default — nothing was squeezed)
-            (cls._import_squeezed_empty_filename, _data, {}),
-            # Legacy file: delete squeezed_scan_dims to simulate a file written by an
-            # older pydidas version that never wrote the key.
-            (cls._import_legacy_squeezed_filename, _data, {}),
-            # Legacy file: no squeezed_scan_dims key; data shape does NOT match (no squeeze).
-            (cls._import_legacy_no_match_filename, _mismatched_data, {}),
-        ]:
-            create_hdf5_results_file(
-                _name,
-                _dset,
-                _scan_dict,
-                _exp_dict,
-                TREE,
-                node_label="Label",
-                plugin_name="SomePlugin",
-                **_extra_kwargs,
-            )
+    scan_dict = scan.get_param_values_as_dict(filter_types_for_export=True)
+    exp_dict = EXP.get_param_values_as_dict(filter_types_for_export=True)
 
-        with h5py.File(cls._import_legacy_squeezed_filename, "r+") as _file:
-            del _file["entry/pydidas_config/squeezed_scan_dims"]
-        with h5py.File(cls._import_legacy_no_match_filename, "r+") as _file:
-            del _file["entry/pydidas_config/squeezed_scan_dims"]
+    import_squeezed_filename = temp_path / "import_test_squeezed.h5"
+    import_squeezed_empty_filename = temp_path / "import_test_squeezed_empty.h5"
+    import_legacy_squeezed_filename = temp_path / "import_test_legacy_squeezed.h5"
+    import_legacy_no_match_filename = temp_path / "import_test_legacy_no_match.h5"
 
-    @classmethod
-    def _create_h5_test_file(cls):
-        cls._import_test_filename = cls._dir / "import_test.h5"
-        cls._data = Dataset(
-            np.random.random((9, 9, 27)),
-            data_label=get_random_string(12),
-            data_unit=get_random_string(3),
-            axis_labels={0: "None", 1: None, 2: "Label"},
-            axis_units={0: "u1", 1: "u2", 2: None},
-            axis_ranges={
-                0: np.arange(9),
-                1: np.arange(9) - 3,
-                2: np.linspace(12, -5, num=27),
-            },
-        )
-        cls._io_node_label = get_random_string(9)
-        cls._import_plugin_name = get_random_string(8)
+    for _name, _dset, _extra_kwargs in [
+        (import_squeezed_filename, squeezed_data, {"squeezed_scan_dims": [1]}),
+        (import_squeezed_empty_filename, squeezed_data, {}),
+        (import_legacy_squeezed_filename, squeezed_data, {}),
+        (import_legacy_no_match_filename, mismatched_data, {}),
+    ]:
         create_hdf5_results_file(
-            cls._import_test_filename,
-            cls._data,
-            SCAN.get_param_values_as_dict(filter_types_for_export=True),
-            EXP.get_param_values_as_dict(filter_types_for_export=True),
+            _name,
+            _dset,
+            scan_dict,
+            exp_dict,
             TREE,
-            node_label=cls._io_node_label,
-            plugin_name=cls._import_plugin_name,
+            node_label="Label",
+            plugin_name="SomePlugin",
+            **_extra_kwargs,
         )
 
-    def setUp(self): ...
+    with h5py.File(import_legacy_squeezed_filename, "r+") as _file:
+        del _file["entry/pydidas_config/squeezed_scan_dims"]
+    with h5py.File(import_legacy_no_match_filename, "r+") as _file:
+        del _file["entry/pydidas_config/squeezed_scan_dims"]
 
-    def tearDown(self): ...
+    yield {
+        "import_test_filename": import_test_filename,
+        "io_node_label": io_node_label,
+        "import_plugin_name": import_plugin_name,
+        "data": data,
+        "data_shape": data_shape,
+        "mismatched_data_shape": mismatched_data_shape,
+        "squeezed_import_data": squeezed_data,
+        "import_squeezed_filename": import_squeezed_filename,
+        "import_squeezed_empty_filename": import_squeezed_empty_filename,
+        "import_legacy_squeezed_filename": import_legacy_squeezed_filename,
+        "import_legacy_no_match_filename": import_legacy_no_match_filename,
+    }
 
-    def prepare_with_defaults(self):
-        self._shapes = {
-            1: SCAN.shape + (12, 7),
-            2: SCAN.shape + (23,),
-            3: SCAN.shape + (1, 3, 7),
+
+@pytest.fixture
+def default_shapes(setup_module_data):
+    """Fixture providing default shapes and related test data."""
+    shapes = {
+        1: SCAN.shape + (12, 7),
+        2: SCAN.shape + (23,),
+        3: SCAN.shape + (1, 3, 7),
+    }
+    labels = {1: "Test", 2: "not again", 3: "another"}
+    _data_labels = {1: "Intensity", 2: "Peak height", 3: "Area"}
+    _data_units = {1: "a.u.", 2: "km", 3: "square inch"}
+    plugin_names = {1: "A plugin", 2: "Plugin no 2.", 3: "Ye olde plugin"}
+    filenames = {
+        1: "node_01_Test.nxs",
+        2: "node_02_not_again.nxs",
+        3: "node_03_another.nxs",
+    }
+
+    return {
+        "shapes": shapes,
+        "labels": labels,
+        "data_labels": _data_labels,
+        "data_units": _data_units,
+        "plugin_names": plugin_names,
+        "filenames": filenames,
+    }
+
+
+@pytest.fixture
+def setup_test_files(empty_temp_path, default_shapes):
+    """Fixture to set up test files and directories for each test."""
+    _node_infos = {
+        _node: {
+            "node_label": default_shapes["labels"][_node],
+            "data_label": default_shapes["data_labels"][_node],
+            "data_unit": default_shapes["data_units"][_node],
+            "shape": default_shapes["shapes"][_node],
+            "plugin_name": default_shapes["plugin_names"][_node],
         }
-        self._labels = {1: "Test", 2: "not again", 3: "another"}
-        self._datalabels = {1: "Intensity", 2: "Peak height", 3: "Area"}
-        self._dataunits = {1: "a.u.", 2: "km", 3: "square inch"}
-        self._plugin_names = {1: "A plugin", 2: "Plugin no 2.", 3: "Ye olde plugin"}
-        self._filenames = {
-            1: "node_01_Test.nxs",
-            2: "node_02_not_again.nxs",
-            3: "node_03_another.nxs",
-        }
-        _node_infos = {
-            _node: {
-                "node_label": self._labels[_node],
-                "data_label": self._datalabels[_node],
-                "data_unit": self._dataunits[_node],
-                "shape": self._shapes[_node],
-                "plugin_name": self._plugin_names[_node],
-            }
-            for _node in self._shapes.keys()
-        }
-        self._resdir = self._dir / get_random_string(8)
-        H5SAVER.prepare_files_and_directories(self._resdir, _node_infos)
+        for _node in default_shapes["shapes"].keys()
+    }
+    H5SAVER.prepare_files_and_directories(empty_temp_path, _node_infos)
 
-    def get_datasets(self, start_dim=3):
-        return {
-            _key: create_dataset(len(_shape[start_dim:]), shape=_shape[start_dim:])
-            for _key, _shape in self._shapes.items()
-        }
+    yield {
+        "result_dir": empty_temp_path,
+        "shapes": default_shapes["shapes"],
+        "labels": default_shapes["labels"],
+        "data_labels": default_shapes["data_labels"],
+        "data_units": default_shapes["data_units"],
+        "filenames": default_shapes["filenames"],
+    }
 
-    def assert_written_files_are_okay(self, data, metadata):
-        for _node_id in self._shapes:
-            _fname = self._resdir / self._filenames[_node_id]
-            with h5py.File(_fname, "r") as _file:
-                self.assertEqual(
-                    _file["entry/data"].attrs["title"],
-                    metadata[_node_id]["data_label"],
-                )
-                self.assertEqual(
-                    _file["entry/data/data"].attrs["units"],
-                    metadata[_node_id]["data_unit"],
-                )
-                for _ax in range(3, data[_node_id].ndim):
-                    _axentry = _file[f"entry/data/axis_{_ax}"]
-                    self.assertEqual(
-                        read_and_decode_hdf5_dataset(_axentry["label"]),
-                        metadata[_node_id]["axis_labels"][_ax - 3],
-                    )
-                    self.assertEqual(
-                        read_and_decode_hdf5_dataset(_axentry["unit"]),
-                        metadata[_node_id]["axis_units"][_ax - 3],
-                    )
-                    self.assertEqual(
-                        read_and_decode_hdf5_dataset(_axentry["range"]),
-                        metadata[_node_id]["axis_ranges"][_ax - 3],
-                    )
 
-    def test_class(self):
-        self.assertEqual(H5SAVER.__class__, META)
+def get_datasets(shapes, start_dim=3):
+    """Helper function to create datasets with specified shapes."""
+    return {
+        _key: create_dataset(len(_shape[start_dim:]), shape=_shape[start_dim:])
+        for _key, _shape in shapes.items()
+    }
 
-    def test_prepare_files_and_directories(self):
-        self.prepare_with_defaults()
-        self.assertTrue(self._resdir.exists())
-        self.assertEqual(H5SAVER.get_attribute_dict("shape"), self._shapes)
-        self.assertEqual(H5SAVER.get_attribute_dict("node_label"), self._labels)
-        for _key in self._shapes:
-            _fname = H5SAVER._filenames[_key]
-            self.assertEqual(_fname, self._filenames[_key])
-            self.assertTrue((self._resdir / _fname).exists())
 
-    def test_create_file_and_populate_metadata(self):
-        _node_id = 1
-        self.prepare_with_defaults()
-        H5SAVER._create_file_and_populate_metadata(_node_id, SCAN, EXP, TREE)
-        with h5py.File(self._resdir / self._filenames[1], "r") as _file:
-            _data = _file["entry/data/data"]
-            self.assertEqual(_data.shape, self._shapes[1])
-            self.assertIsInstance(_data, h5py.Dataset)
-
-    def test_update_with_scan_metadata(self):
-        self.prepare_with_defaults()
-        _datasets = self.get_datasets()
-        _metadata = H5SAVER.update_with_scan_metadata(_datasets, SCAN)
-        for _key, _metadata in _metadata.items():
-            self.assertEqual(_metadata["data_label"], _datasets[_key].data_label)
-            self.assertEqual(_metadata["data_unit"], _datasets[_key].data_unit)
-            for _dim in range(SCAN.ndim):
-                self.assertEqual(_metadata["axis_labels"][_dim], SCAN.axis_labels[_dim])
-                self.assertEqual(_metadata["axis_units"][_dim], SCAN.axis_units[_dim])
-                self.assertTrue(
-                    np.allclose(_metadata["axis_ranges"][_dim], SCAN.axis_ranges[_dim])
-                )
-            for _dim in range(_datasets[_key].ndim - SCAN.ndim):
-                self.assertEqual(
-                    _metadata["axis_labels"][_dim + SCAN.ndim],
-                    _datasets[_key].axis_labels[_dim],
-                )
-                self.assertEqual(
-                    _metadata["axis_units"][_dim + SCAN.ndim],
-                    _datasets[_key].axis_units[_dim],
-                )
-                self.assertTrue(
-                    np.allclose(
-                        _metadata["axis_ranges"][_dim + SCAN.ndim],
-                        _datasets[_key].axis_ranges[_dim],
-                    )
-                )
-
-    def test_update_metadata__standard(self):
-        self.prepare_with_defaults()
-        _data = {
-            _key: create_dataset(len(_shape[3:]), shape=_shape[3:])
-            for _key, _shape in self._shapes.items()
-        }
-        _metadata = {
-            _key: dict(
-                axis_units=_item.axis_units,
-                axis_labels=_item.axis_labels,
-                axis_ranges=_item.axis_ranges,
-                data_label=_data[_key].data_label,
-                data_unit=_data[_key].data_unit,
-            )
-            for _key, _item in _data.items()
-        }
-        H5SAVER.update_metadata(_metadata)
-        self.assert_written_files_are_okay(_data, _metadata)
-
-    def test_export_full_data_to_file(self):
-        self.prepare_with_defaults()
-        _data = self.get_datasets(start_dim=0)
-        H5SAVER.export_full_data_to_file(_data, SCAN)
-        for _node_id in self._shapes:
-            _fname = self._resdir / self._filenames[_node_id]
-            with h5py.File(_fname, "r") as _file:
-                _writtendata = _file["entry/data/data"][()]
-            self.assertTrue(np.allclose(_data[_node_id], _writtendata))
-
-    def test_export_full_data_to_file__same_dataset(self):
-        self.prepare_with_defaults()
-        _data = self.get_datasets(start_dim=1)
-        H5SAVER.export_full_data_to_file(_data, SCAN)
-        _data = self.get_datasets(start_dim=0)
-        H5SAVER.export_full_data_to_file(_data)
-        for _node_id in self._shapes:
-            _fname = self._resdir / self._filenames[_node_id]
-            with h5py.File(_fname, "r") as _file:
-                _writtendata = _file["entry/data/data"][()]
-            self.assertTrue(np.allclose(_data[_node_id], _writtendata))
-
-    def test_export_frame_to_file(self):
-        self.prepare_with_defaults()
-        _data = self.get_datasets()
-        _index = 5
-        _scan_indices = SCAN.get_indices_from_ordinal(_index)
-        H5SAVER.export_frame_to_file(_index, _data, SCAN)
-        for _node_id in self._shapes:
-            _fname = self._resdir / self._filenames[_node_id]
-            with h5py.File(_fname, "r") as _file:
-                _written_data = _file["entry/data/data"][_scan_indices]
-            self.assertTrue(np.allclose(_written_data, _data[_node_id].array))
-
-    def test_import_results_from_file(self):
-        _data, _node_info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
-            self._import_test_filename
-        )
-        self.assertEqual(_node_info["node_label"], self._io_node_label)
-        self.assertEqual(_data.data_label, self._data.data_label)
-        for _ax in range(_data.ndim):
-            self.assertEqual(self._data.axis_labels[_ax], _data.axis_labels[_ax])
-            self.assertEqual(self._data.axis_units[_ax], _data.axis_units[_ax])
-            if isinstance(self._data.axis_ranges[_ax], np.ndarray):
-                self.assertTrue(
-                    np.allclose(self._data.axis_ranges[_ax], _data.axis_ranges[_ax])
-                )
-            else:
-                self.assertEqual(self._data.axis_ranges[_ax], _data.axis_ranges[_ax])
-        for _key, _param in EXP.params.items():
-            if _param.dtype == Real:
-                self.assertAlmostEqual(_param.value, _exp.get_param_value(_key))
-            else:
-                self.assertEqual(_param.value, _exp.get_param_value(_key))
-        for _key, _param in SCAN.params.items():
-            if _param.dtype == Real:
-                self.assertAlmostEqual(_param.value, _scan.get_param_value(_key))
-            else:
-                self.assertEqual(_param.value, _scan.get_param_value(_key))
-
-    def test_import_results_from_file__with_missing_data(self):
-        _new_name = self._dir / "import_test_with_None.h5"
-        shutil.copy(self._import_test_filename, _new_name)
-        with h5py.File(_new_name, "r+") as _file:
-            del _file["entry/pydidas_config/scan/scan_dim0_n_points"]
-            del _file["entry/pydidas_config/scan/scan_dim0_unit"]
-            del _file["entry/pydidas_config/scan/scan_dim0_label"]
-        with self.assertRaises(UserConfigError):
-            _data, _node_info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
-                _new_name
-            )
-
-    def test_insert_squeezed_scan_dims__single_dim(self):
-        _scan = _make_scan_with_size1_dims(3, 1)
-        _data = Dataset(
-            np.random.random(_scan.squeezed_shape + self._data_shape),
-            axis_labels={
-                0: _scan.axis_labels[0],
-                1: _scan.axis_labels[2],
-                2: "data_label0",
-                3: "data_label1",
-            },
-            axis_units={
-                0: _scan.axis_units[0],
-                1: _scan.axis_units[2],
-                2: "data_unit",
-                3: "data_unit B",
-            },
-            axis_ranges={
-                0: _scan.axis_ranges[0],
-                1: _scan.axis_ranges[2],
-                2: np.linspace(11, 12, self._data_shape[0]),
-                3: np.linspace(0, 2, self._data_shape[1]),
-            },
-        )
-        _result = H5SAVER._insert_squeezed_scan_dims(_data, _scan, [1])
-        self.assertEqual(_result.shape, _scan.shape + self._data_shape)
-        for _dim in [0, 1, 2]:
-            self.assertEqual(
-                _result.axis_labels[_dim],
-                _scan.get_param_value(f"scan_dim{_dim}_label"),
-            )
-            self.assertEqual(
-                _result.axis_units[_dim], _scan.get_param_value(f"scan_dim{_dim}_unit")
-            )
-        self.assertTrue(np.allclose(_result.squeeze(), _data))
-
-    def test_insert_squeezed_scan_dims__multiple_dims(self):
-        _scan = _make_scan_with_size1_dims(3, 0, 2)
-        _data_shape = (12,)
-        _data = Dataset(
-            np.random.random(_scan.squeezed_shape + _data_shape),
-            axis_labels={0: "motor1_ax", 1: "intensity"},
-            axis_units={0: "deg", 1: "a.u."},
-            axis_ranges={
-                0: np.linspace(0, 0.4, _scan.shape[1]),
-                1: np.arange(_data_shape[0], dtype=float),
-            },
-        )
-        _result = H5SAVER._insert_squeezed_scan_dims(_data, _scan, [0, 2])
-        self.assertEqual(_result.shape, _scan.shape + _data_shape)
-        self.assertEqual(_result.axis_labels[0], _scan.axis_labels[0])
-        self.assertEqual(_result.axis_labels[1], _data.axis_labels[0])
-        self.assertEqual(_result.axis_labels[2], _scan.axis_labels[2])
-        self.assertEqual(_result.axis_labels[3], _data.axis_labels[1])
-        self.assertTrue(np.allclose(_result.squeeze(), _data))
-
-    def test_update_metadata__with_squeeze(self):
-        _scan = _make_scan_with_size1_dims(3, 1)
-        _plugin_shape = (12, 7)
-        _full_shape = _scan.shape + _plugin_shape
-        _node_infos = {
-            1: {
-                "node_label": "SqueezedNode",
-                "data_label": "Intensity",
-                "data_unit": "a.u.",
-                "shape": _plugin_shape,
-                "plugin_name": "SomeProcPlugin",
-            }
-        }
-        _resdir = self._dir / get_random_string(8)
-        H5SAVER.prepare_files_and_directories(_resdir, _node_infos, scan_context=_scan)
-        _data = Dataset(
-            np.random.random(_full_shape),
-            axis_labels={i: f"ax{i}" for i in range(len(_full_shape))},
-            axis_units={i: f"u{i}" for i in range(len(_full_shape))},
-            axis_ranges={
-                i: np.arange(_full_shape[i], dtype=float)
-                for i in range(len(_full_shape))
-            },
-        )
-        H5SAVER.update_metadata({1: _data}, scan=_scan, squeeze=True)
-        _fname = _resdir / H5SAVER._filenames[1]
+def assert_written_files_are_okay(_result_dir, data, metadata, filenames, shapes):
+    """Helper function to assert that written HDF5 files are correct."""
+    for _node_id in shapes:
+        _fname = _result_dir / filenames[_node_id]
         with h5py.File(_fname, "r") as _file:
-            _squeezed_dims = list(_file["entry/pydidas_config/squeezed_scan_dims"][()])
-        self.assertEqual(_squeezed_dims, [1])
+            assert (
+                _file["entry/data"].attrs["title"] == metadata[_node_id]["data_label"]
+            )
+            assert (
+                _file["entry/data/data"].attrs["units"]
+                == metadata[_node_id]["data_unit"]
+            )
+            for _ax in range(3, data[_node_id].ndim):
+                _ax_entry = _file[f"entry/data/axis_{_ax}"]
+                assert (
+                    read_and_decode_hdf5_dataset(_ax_entry["label"])
+                    == metadata[_node_id]["axis_labels"][_ax - 3]
+                )
+                assert (
+                    read_and_decode_hdf5_dataset(_ax_entry["unit"])
+                    == metadata[_node_id]["axis_units"][_ax - 3]
+                )
+                assert np.array_equal(
+                    read_and_decode_hdf5_dataset(_ax_entry["range"]),
+                    metadata[_node_id]["axis_ranges"][_ax - 3],
+                )
 
-    def test_export_full_data_to_file__with_squeeze(self):
-        _scan = _make_scan_with_size1_dims(3, 1)
-        _plugin_shape = (12, 7)
-        _full_shape = _scan.shape + _plugin_shape
-        _squeezed_shape = _scan.squeezed_shape + _plugin_shape
-        _node_infos = {
-            1: {
-                "node_label": "SqueezedNode",
-                "data_label": "Intensity",
-                "data_unit": "a.u.",
-                "shape": _squeezed_shape,
-                "plugin_name": "SomeProcPlugin",
-            }
+
+def test_class():
+    assert H5SAVER.__class__ == META
+
+
+def test_prepare_files_and_directories(setup_test_files):
+    _result_dir: Path = setup_test_files["result_dir"]  # type: ignore[type] # type: ignore[type]
+    shapes = setup_test_files["shapes"]
+    labels = setup_test_files["labels"]
+    filenames = setup_test_files["filenames"]
+    assert _result_dir.exists()
+    # prepare_files_and_directories was called in the ``setup_test_files`` fixture
+    assert H5SAVER.get_attribute_dict("shape") == shapes
+    assert H5SAVER.get_attribute_dict("node_label") == labels
+    for _key in shapes:
+        _fname = H5SAVER._filenames[_key]
+        assert _fname == filenames[_key]
+        assert (_result_dir / _fname).exists()
+
+
+def test_create_file_and_populate_metadata(setup_test_files):
+    _result_dir: Path = setup_test_files["result_dir"]  # type: ignore[type]
+    shapes = setup_test_files["shapes"]
+    filenames = setup_test_files["filenames"]
+    _node_id = 1
+    H5SAVER._create_file_and_populate_metadata(_node_id, SCAN, EXP, TREE)
+    with h5py.File(_result_dir / filenames[1], "r") as _file:
+        _data = _file["entry/data/data"]
+        assert _data.shape == shapes[1]
+        assert isinstance(_data, h5py.Dataset)
+
+
+def test_update_with_scan_metadata(setup_test_files):
+    shapes = setup_test_files["shapes"]
+
+    _datasets = get_datasets(shapes)
+    _metadata = H5SAVER.update_with_scan_metadata(_datasets, SCAN)
+    for _key, _metadata_item in _metadata.items():
+        assert _metadata_item["data_label"] == _datasets[_key].data_label
+        assert _metadata_item["data_unit"] == _datasets[_key].data_unit
+        for _dim in range(SCAN.ndim):
+            assert _metadata_item["axis_labels"][_dim] == SCAN.axis_labels[_dim]
+            assert _metadata_item["axis_units"][_dim] == SCAN.axis_units[_dim]
+            assert np.allclose(
+                _metadata_item["axis_ranges"][_dim], SCAN.axis_ranges[_dim]
+            )
+        for _dim in range(_datasets[_key].ndim - SCAN.ndim):
+            assert (
+                _metadata_item["axis_labels"][_dim + SCAN.ndim]
+                == _datasets[_key].axis_labels[_dim]
+            )
+            assert (
+                _metadata_item["axis_units"][_dim + SCAN.ndim]
+                == _datasets[_key].axis_units[_dim]
+            )
+            assert np.allclose(
+                _metadata_item["axis_ranges"][_dim + SCAN.ndim],
+                _datasets[_key].axis_ranges[_dim],
+            )
+
+
+def test_update_metadata__standard(setup_test_files):
+    _result_dir: Path = setup_test_files["result_dir"]  # type: ignore[type]
+    shapes = setup_test_files["shapes"]
+    filenames = setup_test_files["filenames"]
+
+    _data = {
+        _key: create_dataset(len(_shape[3:]), shape=_shape[3:])
+        for _key, _shape in shapes.items()
+    }
+    _metadata = {
+        _key: dict(
+            axis_units=_item.axis_units,
+            axis_labels=_item.axis_labels,
+            axis_ranges=_item.axis_ranges,
+            data_label=_data[_key].data_label,
+            data_unit=_data[_key].data_unit,
+        )
+        for _key, _item in _data.items()
+    }
+    H5SAVER.update_metadata(_metadata)
+    assert_written_files_are_okay(_result_dir, _data, _metadata, filenames, shapes)
+
+
+def test_export_full_data_to_file(setup_test_files):
+    _result_dir: Path = setup_test_files["result_dir"]  # type: ignore[type]
+    shapes = setup_test_files["shapes"]
+    filenames = setup_test_files["filenames"]
+
+    _data = get_datasets(shapes, start_dim=0)
+    H5SAVER.export_full_data_to_file(_data, SCAN)
+    for _node_id in shapes:
+        _fname = _result_dir / filenames[_node_id]
+        with h5py.File(_fname, "r") as _file:
+            _written_data = _file["entry/data/data"][()]
+        assert np.allclose(_data[_node_id], _written_data)
+
+
+def test_export_full_data_to_file__same_dataset(setup_test_files):
+    _result_dir: Path = setup_test_files["result_dir"]  # type: ignore[type]
+    shapes = setup_test_files["shapes"]
+    filenames = setup_test_files["filenames"]
+
+    _data = get_datasets(shapes, start_dim=1)
+    H5SAVER.export_full_data_to_file(_data, SCAN)
+    _data = get_datasets(shapes, start_dim=0)
+    H5SAVER.export_full_data_to_file(_data)
+    for _node_id in shapes:
+        _fname = _result_dir / filenames[_node_id]
+        with h5py.File(_fname, "r") as _file:
+            _written_data = _file["entry/data/data"][()]
+        assert np.allclose(_data[_node_id], _written_data)
+
+
+def test_export_frame_to_file(setup_test_files):
+    _result_dir: Path = setup_test_files["result_dir"]  # type: ignore[type]
+    shapes = setup_test_files["shapes"]
+    filenames = setup_test_files["filenames"]
+
+    _data = get_datasets(shapes)
+    _index = 5
+    _scan_indices = SCAN.get_indices_from_ordinal(_index)
+    H5SAVER.export_frame_to_file(_index, _data, SCAN)
+    for _node_id in shapes:
+        _fname = _result_dir / filenames[_node_id]
+        with h5py.File(_fname, "r") as _file:
+            _written_data = _file["entry/data/data"][_scan_indices]
+        assert np.allclose(_written_data, _data[_node_id].array)
+
+
+def test_import_results_from_file(setup_module_data):
+    _fname: Path = setup_module_data["import_test_filename"]  # type: ignore[type]
+    _data, _node_info, _scan, _exp, _tree = H5SAVER.import_results_from_file(_fname)
+    _input_data: Dataset = setup_module_data["data"]  # type: ignore[type]
+    assert _node_info["node_label"] == setup_module_data["io_node_label"]
+    assert _data.data_label == _input_data.data_label
+    for _ax in range(_data.ndim):
+        assert _input_data.axis_labels[_ax] == _data.axis_labels[_ax]
+        assert _input_data.axis_units[_ax] == _data.axis_units[_ax]
+        if isinstance(_input_data.axis_ranges[_ax], np.ndarray):
+            assert np.allclose(
+                _input_data.axis_ranges[_ax],
+                _data.axis_ranges[_ax],
+            )
+        else:
+            assert _input_data.axis_ranges[_ax] == _data.axis_ranges[_ax]
+    for _key, _param in EXP.params.items():
+        if _param.dtype == Real:
+            assert abs(_param.value - _exp.get_param_value(_key)) < 1e-7
+        else:
+            assert _param.value == _exp.get_param_value(_key)
+    for _key, _param in SCAN.params.items():
+        if _param.dtype == Real:
+            assert abs(_param.value - _scan.get_param_value(_key)) < 1e-7
+        else:
+            assert _param.value == _scan.get_param_value(_key)
+
+
+def test_import_results_from_file__with_missing_data(
+    setup_module_data, empty_temp_path
+):
+    _fname: Path = setup_module_data["import_test_filename"]  # type: ignore[type]
+    _new_name = empty_temp_path / "import_test_with_None.h5"
+    shutil.copy(_fname, _new_name)
+    with h5py.File(_new_name, "r+") as _file:
+        del _file["entry/pydidas_config/scan/scan_dim0_n_points"]
+        del _file["entry/pydidas_config/scan/scan_dim0_unit"]
+        del _file["entry/pydidas_config/scan/scan_dim0_label"]
+    with pytest.raises(UserConfigError):
+        _data, _node_info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
+            _new_name
+        )
+
+
+def test_insert_squeezed_scan_dims__single_dim(setup_module_data):
+    data_shape = setup_module_data["data_shape"]
+    _scan = _make_scan_with_size1_dims(3, 1)
+    _data = Dataset(
+        np.random.random(_scan.squeezed_shape + data_shape),
+        axis_labels={
+            0: _scan.axis_labels[0],
+            1: _scan.axis_labels[2],
+            2: "data_label0",
+            3: "data_label1",
+        },
+        axis_units={
+            0: _scan.axis_units[0],
+            1: _scan.axis_units[2],
+            2: "data_unit",
+            3: "data_unit B",
+        },
+        axis_ranges={
+            0: _scan.axis_ranges[0],
+            1: _scan.axis_ranges[2],
+            2: np.linspace(11, 12, data_shape[0]),  # type: ignore[type]
+            3: np.linspace(0, 2, data_shape[1]),  # type: ignore[type]
+        },
+    )
+    _result = H5SAVER._insert_squeezed_scan_dims(_data, _scan, [1])
+    assert _result.shape == _scan.shape + data_shape
+    for _dim in [0, 1, 2]:
+        assert _result.axis_labels[_dim] == _scan.get_param_value(
+            f"scan_dim{_dim}_label"
+        )
+        assert _result.axis_units[_dim] == _scan.get_param_value(f"scan_dim{_dim}_unit")
+    assert np.allclose(_result.squeeze(), _data)
+
+
+def test_insert_squeezed_scan_dims__multiple_dims():
+    _scan = _make_scan_with_size1_dims(3, 0, 2)
+    _data_shape = (12,)
+    _data = Dataset(
+        np.random.random(_scan.squeezed_shape + _data_shape),
+        axis_labels={0: "motor1_ax", 1: "intensity"},
+        axis_units={0: "deg", 1: "a.u."},
+        axis_ranges={
+            0: np.linspace(0, 0.4, _scan.shape[1]),
+            1: np.arange(_data_shape[0], dtype=float),
+        },
+    )
+    _result = H5SAVER._insert_squeezed_scan_dims(_data, _scan, [0, 2])
+    assert _result.shape == _scan.shape + _data_shape
+    assert _result.axis_labels[0] == _scan.axis_labels[0]
+    assert _result.axis_labels[1] == _data.axis_labels[0]
+    assert _result.axis_labels[2] == _scan.axis_labels[2]
+    assert _result.axis_labels[3] == _data.axis_labels[1]
+    assert np.allclose(_result.squeeze(), _data)
+
+
+def test_update_metadata__with_squeeze(empty_temp_path):
+    _scan = _make_scan_with_size1_dims(3, 1)
+    _plugin_shape = (12, 7)
+    _full_shape = _scan.shape + _plugin_shape
+    _node_infos = {
+        1: {
+            "node_label": "SqueezedNode",
+            "data_label": "Intensity",
+            "data_unit": "a.u.",
+            "shape": _plugin_shape,
+            "plugin_name": "SomeProcPlugin",
         }
-        _resdir = self._dir / get_random_string(8)
-        H5SAVER.prepare_files_and_directories(_resdir, _node_infos, scan_context=_scan)
-        _full_data = {1: Dataset(np.random.random(_full_shape))}
-        H5SAVER.export_full_data_to_file(_full_data, scan_context=_scan, squeeze=True)
-        with h5py.File(_resdir / H5SAVER._filenames[1], "r") as _file:
-            _written = _file["entry/data/data"][()]
-            _squeezed_dims = list(_file["entry/pydidas_config/squeezed_scan_dims"][()])
-        self.assertEqual(_written.shape, _squeezed_shape)
-        self.assertTrue(np.allclose(_written, _full_data[1].squeeze().array))
-        self.assertEqual(_squeezed_dims, [1])
+    }
+    H5SAVER.prepare_files_and_directories(
+        empty_temp_path, _node_infos, scan_context=_scan
+    )
+    _data = Dataset(
+        np.random.random(_full_shape),
+        axis_labels={i: f"ax{i}" for i in range(len(_full_shape))},
+        axis_units={i: f"u{i}" for i in range(len(_full_shape))},
+        axis_ranges={
+            i: np.arange(_full_shape[i], dtype=float) for i in range(len(_full_shape))
+        },
+    )
+    H5SAVER.update_metadata({1: _data}, scan=_scan, squeeze=True)
+    _fname = empty_temp_path / H5SAVER._filenames[1]
+    with h5py.File(_fname, "r") as _file:
+        _squeezed_dims = list(_file["entry/pydidas_config/squeezed_scan_dims"][()])
+    assert _squeezed_dims == [1]
 
-    def test_import_results_from_file__with_squeezed_dims_flag(self):
-        """Test to check that data was re-inserted for squeezed dim"""
-        _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
-            self._import_squeezed_filename
-        )
-        self.assertEqual(_data.shape, _scan.shape + self._data_shape)
-        self.assertEqual(_data.axis_labels[1], _scan.axis_labels[1])
-        self.assertEqual(_data.axis_units[1], _scan.axis_units[1])
-        self.assertEqual(
-            _data.axis_labels[0], self._squeezed_import_data.axis_labels[0]
-        )
 
-    def test_import_results_from_file__with_empty_squeezed_dims_flag(self):
-        """Test to check that no data was re-inserted for squeezed dim"""
-        _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
-            self._import_squeezed_empty_filename
-        )
-        _expected_shape = _scan.squeezed_shape + self._data_shape
-        self.assertEqual(_data.shape, _expected_shape)
+def test_export_full_data_to_file__with_squeeze(empty_temp_path):
+    _scan = _make_scan_with_size1_dims(3, 1)
+    _plugin_shape = (12, 7)
+    _full_shape = _scan.shape + _plugin_shape
+    _squeezed_shape = _scan.squeezed_shape + _plugin_shape
+    _node_infos = {
+        1: {
+            "node_label": "SqueezedNode",
+            "data_label": "Intensity",
+            "data_unit": "a.u.",
+            "shape": _squeezed_shape,
+            "plugin_name": "SomeProcPlugin",
+        }
+    }
+    H5SAVER.prepare_files_and_directories(
+        empty_temp_path, _node_infos, scan_context=_scan
+    )
+    _full_data = {1: Dataset(np.random.random(_full_shape))}
+    H5SAVER.export_full_data_to_file(_full_data, scan_context=_scan, squeeze=True)
+    with h5py.File(empty_temp_path / H5SAVER._filenames[1], "r") as _file:
+        _written = _file["entry/data/data"][()]
+        _squeezed_dims = list(_file["entry/pydidas_config/squeezed_scan_dims"][()])
+    assert _written.shape == _squeezed_shape
+    assert np.allclose(_written, _full_data[1].squeeze().array)
+    assert _squeezed_dims == [1]
 
-    def test_import_results_from_file__legacy_squeezed_dims(self):
-        """Test to check that data was re-inserted if key is misssing"""
-        _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
-            self._import_legacy_squeezed_filename
-        )
-        self.assertEqual(_data.shape, _scan.shape + self._data_shape)
-        self.assertEqual(_data.axis_labels[1], _scan.axis_labels[1])
-        self.assertEqual(_data.axis_units[1], _scan.axis_units[1])
 
-    def test_import_results_from_file__legacy_size1_dims_shape_no_match(self):
-        """Without key and shape mismatch, data should stay the same"""
-        _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(
-            self._import_legacy_no_match_filename
-        )
-        self.assertEqual(_data.shape, self._mismatched_data_shape)
+def test_import_results_from_file__with_squeezed_dims_flag(setup_module_data):
+    """Test to check that data was re-inserted for squeezed dim"""
+    _fname: Path = setup_module_data["import_squeezed_filename"]  # type: ignore[type]
+    _import_data: Dataset = setup_module_data["squeezed_import_data"]  # type: ignore[type]
+    _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(_fname)
+    data_shape = setup_module_data["data_shape"]
+    assert _data.shape == _scan.shape + data_shape
+    assert _data.axis_labels[1] == _scan.axis_labels[1]
+    assert _data.axis_units[1] == _scan.axis_units[1]
+    assert _data.axis_labels[0] == _import_data.axis_labels[0]
+
+
+def test_import_results_from_file__with_empty_squeezed_dims_flag(setup_module_data):
+    """Test to check that no data was re-inserted for squeezed dim"""
+    _fname: Path = setup_module_data["import_squeezed_empty_filename"]  # type: ignore[type]
+    _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(_fname)
+    data_shape = setup_module_data["data_shape"]
+    _expected_shape = _scan.squeezed_shape + data_shape
+    assert _data.shape == _expected_shape
+
+
+def test_import_results_from_file__legacy_squeezed_dims(setup_module_data):
+    """Test to check that data was re-inserted if key is missing"""
+    _fname: Path = setup_module_data["import_legacy_squeezed_filename"]  # type: ignore[type]
+    _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(_fname)
+    data_shape = setup_module_data["data_shape"]
+    assert _data.shape == _scan.shape + data_shape
+    assert _data.axis_labels[1] == _scan.axis_labels[1]
+    assert _data.axis_units[1] == _scan.axis_units[1]
+
+
+def test_import_results_from_file__legacy_size1_dims_shape_no_match(setup_module_data):
+    """Without key and shape mismatch, data should stay the same"""
+    _fname: Path = setup_module_data["import_legacy_no_match_filename"]  # type: ignore[type]
+    _data, _info, _scan, _exp, _tree = H5SAVER.import_results_from_file(_fname)
+    assert _data.shape == setup_module_data["mismatched_data_shape"]
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main()

--- a/tests/workflow/result_io/test_processing_result_io_meta.py
+++ b/tests/workflow/result_io/test_processing_result_io_meta.py
@@ -238,21 +238,6 @@ class TestProcessingResultsSaverMeta(unittest.TestCase):
         self.assertTrue(np.allclose(_Saver._exported["full_data"][1], _results[1]))
         self.assertTrue(np.allclose(_Saver._exported["full_data"][2], _results[2]))
 
-    def test_export_full_data_to_file(self):
-        _frame_results = {
-            1: np.random.random((10, 10, 10)),
-            2: np.random.random((11, 27, 25)),
-        }
-        _Saver = self.create_saver_class("SAVER", ".Test")
-        _Saver.export_full_data_to_file = classmethod(export_full_data_to_file)
-        META.export_full_data_to_file(".TEST", _frame_results)
-        self.assertTrue(
-            np.allclose(_Saver._exported["full_data"][1], _frame_results[1])
-        )
-        self.assertTrue(
-            np.allclose(_Saver._exported["full_data"][2], _frame_results[2])
-        )
-
     def test_prepare_active_savers(self):
         _save_dir, _node_info = self.get_save_dir_and_node_info()
         _Saver = self.create_saver_class("SAVER", ".Test")

--- a/tests/workflow/test_processing_results.py
+++ b/tests/workflow/test_processing_results.py
@@ -510,6 +510,13 @@ class TestProcessingResults(unittest.TestCase):
         _res = res.get_results_for_flattened_scan(1)
         self.assertEqual(_res.shape, (np.prod(SCAN.shape),) + self._input_shape)
 
+    def test_get_results_for_flattened_scan__w_n1_scan_dim(self) -> None:
+        SCAN.set_param_value("scan_dim0_n_points", 1)
+        res = self.create_standard_workflow_results()
+        _res = res.get_results_for_flattened_scan(1)
+        print(_res.shape)
+        self.assertEqual(_res.shape, (np.prod(SCAN.shape),) + self._input_shape)
+
     def test_get_results_for_flattened_scan__wrong_node_id(self) -> None:
         res = self.create_standard_workflow_results()
         with self.assertRaises(UserConfigError):
@@ -745,7 +752,7 @@ class TestProcessingResults(unittest.TestCase):
             "data_unit": "u2",
         }
         res = self.create_standard_workflow_results()
-        res.save_results_to_disk(self._tmpdir, ".HDF5", squeeze_results=True)
+        res.save_results_to_disk(self._tmpdir, ".HDF5", squeeze=True)
         with h5py.File(self.get_node_output_path(1), "r") as f:
             _shape1 = f["entry/data/data"].shape
         with h5py.File(self.get_node_output_path(2), "r") as f:
@@ -784,7 +791,7 @@ class TestProcessingResults(unittest.TestCase):
     def test_get_node_result_metadata_string__no_squeeze(self) -> None:
         res = self.create_standard_workflow_results()
         _node_info = res.get_node_result_metadata_string(
-            2, use_scan_timeline=False, squeeze_results=False
+            2, use_scan_timeline=False, squeeze=False
         )
         for _dim in range(SCAN.ndim):
             self.assertIn(f"Axis #{_dim:02d} (scan):", _node_info)

--- a/tests/workflow/test_processing_results.py
+++ b/tests/workflow/test_processing_results.py
@@ -514,7 +514,6 @@ class TestProcessingResults(unittest.TestCase):
         SCAN.set_param_value("scan_dim0_n_points", 1)
         res = self.create_standard_workflow_results()
         _res = res.get_results_for_flattened_scan(1)
-        print(_res.shape)
         self.assertEqual(_res.shape, (np.prod(SCAN.shape),) + self._input_shape)
 
     def test_get_results_for_flattened_scan__wrong_node_id(self) -> None:


### PR DESCRIPTION
Fixed an issue with importing data with scan dimensions of size 1 which were squeezed during export. At export, these would interfere with data dimensions and broke displaying data in a scan timeline.