### PR TITLE
Make base_dir and filename public attributes

### DIFF
--- a/src/pydidas/plugins/base_input_plugin.py
+++ b/src/pydidas/plugins/base_input_plugin.py
@@ -73,8 +73,8 @@ class InputPlugin(BasePlugin):
         BasePlugin.__init__(self, *args, **kwargs)
         self._SCAN = kwargs.get("scan", ScanContext())
         self._config["pre_executed"] = False
-        self._base_dir = Path()
-        self._filename = ""
+        self.base_dir = Path()
+        self.filename = ""
         if self.base_output_data_dim == 2:
             self.add_params(
                 get_generic_parameter("roi_ylow"),
@@ -114,8 +114,8 @@ class InputPlugin(BasePlugin):
         The generic implementation only joins the base directory and filename pattern,
         as defined in the ScanContext class.
         """
-        self._base_dir = self._SCAN.get_param_value("scan_base_directory")
-        self._filename = self._SCAN.processed_file_naming_pattern
+        self.base_dir = self._SCAN.get_param_value("scan_base_directory")
+        self.filename = self._SCAN.processed_file_naming_pattern
 
     def input_available(self, ordinal: int) -> bool:
         """
@@ -164,7 +164,7 @@ class InputPlugin(BasePlugin):
         _file_index = _file_counter * self._SCAN.get_param_value(
             "pattern_number_delta"
         ) + self._SCAN.get_param_value("pattern_number_offset")
-        return self._base_dir / self._filename.format(index=_file_index)
+        return self.base_dir / self.filename.format(index=_file_index)
 
     def get_frame(self, frame_index: int, **kwargs: Any) -> tuple[Dataset, dict]:
         """

--- a/src/pydidas_plugins/input_plugins/eiger_scan_series_loader.py
+++ b/src/pydidas_plugins/input_plugins/eiger_scan_series_loader.py
@@ -87,5 +87,5 @@ class EigerScanSeriesLoader(Hdf5fileSeriesLoader):
         _basepath = self._SCAN.get_param_value("scan_base_directory")
         if _pattern.endswith(_suffix):
             _pattern = _pattern.removesuffix(_suffix)
-        self._base_dir = _basepath
-        self._filename = f"{_pattern}/{_eigerkey}/{_pattern}{_suffix}"
+        self.base_dir = _basepath
+        self.filename = f"{_pattern}/{_eigerkey}/{_pattern}{_suffix}"

--- a/src/pydidas_plugins/input_plugins/nxdata_result_loader.py
+++ b/src/pydidas_plugins/input_plugins/nxdata_result_loader.py
@@ -132,7 +132,7 @@ class NXdataResultLoader(InputPlugin):
     def update_filepath(self):
         """Update the stored filepath."""
         InputPlugin.update_filepath(self)
-        self._config["filename"] = self._base_dir / self._filename
+        self._config["filename"] = self.base_dir / self.filename
 
     def pre_execute(self) -> None:
         """Prepare the loader and read required metadata once."""

--- a/tests/_plugin_tests/input_plugins/test_eiger_scan_series_loader.py
+++ b/tests/_plugin_tests/input_plugins/test_eiger_scan_series_loader.py
@@ -86,9 +86,9 @@ def test_update_filepath(
     if _proc_pattern.endswith(eiger_filename_suffix):
         _proc_pattern = _proc_pattern.removesuffix(eiger_filename_suffix)
     plugin.update_filepath()
-    assert plugin._base_dir == Path()
+    assert plugin.base_dir == Path()
     assert (
-        plugin._filename
+        plugin.filename
         == f"{_proc_pattern}/{eiger_dir}/{_proc_pattern}{eiger_filename_suffix}"
     )
 

--- a/tests/_plugin_tests/input_plugins/test_nxdata_results_loader.py
+++ b/tests/_plugin_tests/input_plugins/test_nxdata_results_loader.py
@@ -162,12 +162,12 @@ def test_verify_data_shape_valid__w_invalid_param(config, plugin, key, value):
 
 
 def test_update_filepath(config, plugin, empty_temp_path):
-    plugin._base_dir = Path("a/b")
-    plugin._filename = "abc"
+    plugin.base_dir = Path("a/b")
+    plugin.filename = "abc"
     plugin._config["filename"] = Path("a/b/abc")
     plugin.update_filepath()
-    assert plugin._base_dir == empty_temp_path
-    assert plugin._filename == _FILENAME
+    assert plugin.base_dir == empty_temp_path
+    assert plugin.filename == _FILENAME
     assert plugin._config["filename"] == empty_temp_path / _FILENAME
 
 

--- a/tests/plugins/test_base_input_plugin.py
+++ b/tests/plugins/test_base_input_plugin.py
@@ -54,8 +54,8 @@ class _TestInputPlugin(InputPlugin):
     def __init__(self, filename="", ndim=2):
         self.base_output_data_dim = ndim
         InputPlugin.__init__(self)
-        self._base_dir = Path(filename).parent
-        self._filename = Path(filename).name
+        self.base_dir = Path(filename).parent
+        self.filename = Path(filename).name
 
     def get_frame(self, index, **kwargs):
         _shape = _DUMMY_SHAPE if self.base_output_data_dim == 2 else _DUMMY_SHAPE_1d
@@ -69,7 +69,7 @@ class _TestInputPlugin(InputPlugin):
         return _frame, kwargs
 
     def read_frame(self, index, **kwargs):
-        return import_data(self._base_dir / self._filename, **kwargs)
+        return import_data(self.base_dir / self.filename, **kwargs)
 
     def update_filepath(self):
         pass
@@ -174,7 +174,7 @@ def test_update_filepath__valid_pattern(
         _target = _target.replace(
             "#" * pattern.count("#"), "{index:0" + str(pattern.count("#")) + "d}"
         )
-    assert plugin._base_dir / plugin._filename == Path(_target)
+    assert plugin.base_dir / plugin.filename == Path(_target)
 
 
 @pytest.mark.parametrize("frame_index", [0, 1, 37])


### PR DESCRIPTION
Solves #181 by renaming `_base_dir` and `_filename` to `base_dir` and `filename` in input plugins and their tests