### PR TITLE
Fix raw in image math

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,8 @@ Programmatic changes
 - Added an option to export all Parameter values as export types in
   the ParameterCollection
 - Updated the way pydidas handles font scaling on silx colorbars
+- When importing data, the return datatype in `import_data` calls must
+  be specified with `astype` instead of `datatype`.
 
 
 Bugfixes
@@ -76,6 +78,8 @@ Bugfixes
   ShowInformationForResult popup window.
 - Fixed an issue with the ChangeCanvasAction which was incompatible with the
   latest silx update to 3.1.0
+- Fixed an issue in RawIo class which did not clearly separate input and
+  output datatype assignments.
 
 
 v26.05.19

--- a/src/pydidas/core/lazy_imports/skimage.py
+++ b/src/pydidas/core/lazy_imports/skimage.py
@@ -16,7 +16,7 @@
 # along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
 
 """
-The fabio module holds functions exposed by the fabio package, which
+The skimage module holds functions exposed by the skimage package, which
 are lazily imported to reduce initial loading time.
 """
 

--- a/src/pydidas/core/lazy_imports/skimage.py
+++ b/src/pydidas/core/lazy_imports/skimage.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
+# Copyright 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -16,26 +16,27 @@
 # along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
 
 """
-Module with the PngIo class for exporting png data.
+The fabio module holds functions exposed by the fabio package, which
+are lazily imported to reduce initial loading time.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
-__all__ = []
+__all__ = ["TiffFileError", "imread", "imsave"]
 
 
-from typing import ClassVar
+from typing import TYPE_CHECKING
 
-from pydidas.core.constants.file_extensions import PNG_EXTENSIONS
-from pydidas.data_io.implementations.io_exporter_matplotlib import IoExporterMatplotlib
+from pydidas.core.lazy_imports.lazy_objects import LazyObject
 
 
-class PngIo(IoExporterMatplotlib):
-    """IObase implementation for png files."""
-
-    extensions_export: ClassVar[list[str]] = PNG_EXTENSIONS
-    extensions_import: ClassVar[list[str]] = []
-    format_name: ClassVar[str] = "Png"
+if TYPE_CHECKING:
+    from skimage.io import imread, imsave
+    from tifffile import TiffFileError
+else:
+    imsave = LazyObject("skimage.io", "imsave")
+    imread = LazyObject("skimage.io", "imread")
+    TiffFileError = LazyObject("tifffile", "TiffFileError")

--- a/src/pydidas/data_io/implementations/ascii_io.py
+++ b/src/pydidas/data_io/implementations/ascii_io.py
@@ -16,7 +16,7 @@
 # along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
 
 """
-Module with the TiffIo class for importing and exporting tiff data.
+Module with the AsciiIo class for importing and exporting ASCII data.
 """
 
 __author__ = "Malte Storm"
@@ -25,6 +25,7 @@ __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
 __all__ = []
+
 
 import datetime
 import time
@@ -35,8 +36,16 @@ from typing import Any, ClassVar
 import numpy as np
 
 from pydidas.core import Dataset, UserConfigError
-from pydidas.core.constants import ASCII_EXPORT_EXTENSIONS, ASCII_IMPORT_EXTENSIONS
-from pydidas.core.utils import CatchFileErrors, convert_str_to_number, get_extension
+from pydidas.core.constants import (
+    ASCII_EXPORT_EXTENSIONS,
+    ASCII_IMPORT_EXTENSIONS,
+)
+from pydidas.core.utils import (
+    CatchFileErrors,
+    convert_str_to_number,
+    get_extension,
+    verify_is_new_file_or_replace_set,
+)
 from pydidas.core.utils.ascii_header_decoders import (
     decode_chi_header,
     decode_specfile_header,
@@ -54,8 +63,8 @@ class AsciiIo(IoBase):
     dimensions: ClassVar[list[int]] = [1, 2]
     allows_metadata_import: ClassVar[bool] = True
 
-    @classmethod
-    def export_to_file(cls, filename: str | Path, data: np.ndarray, **kwargs: Any):
+    @staticmethod
+    def export_to_file(filename: str | Path, data: np.ndarray, **kwargs: Any) -> None:
         """
         Export data to file in ASCII format.
 
@@ -68,7 +77,7 @@ class AsciiIo(IoBase):
 
         Parameters
         ----------
-        filename : str | Path
+        filename : str or Path
             The filename
         data : np.ndarray
             The data to be written to file.
@@ -76,16 +85,17 @@ class AsciiIo(IoBase):
             Supported arguments are:
 
             overwrite : bool, optional
-                Flag to allow overwriting of existing files. The default is False.
+                Flag to allow overwriting of existing files. The default
+                is False.
             x_column : bool, optional
                 A flag which indicates whether the x-axis should be written as
-                a first column. If False, only the data array will be written. The
-                default is True.
+                a first column. If False, only the data array will be
+                written. The default is True.
             write_header : bool, optional
                 A flag which indicates whether a metadata header should be
                 written. The default is True.
         """
-        cls.check_for_existing_file(filename, **kwargs)
+        verify_is_new_file_or_replace_set(filename, **kwargs)
         if data.ndim > 2:
             raise UserConfigError("Only 1-d and 2-d data can be saved as ASCII")
         if not isinstance(filename, Path):
@@ -99,14 +109,14 @@ class AsciiIo(IoBase):
         if _ext == ".chi":
             if not _write_x_column:
                 raise UserConfigError("CHI files always need an x-column.")
-            _header = cls.__create_chi_header(filename, data)
+            _header = AsciiIo.__create_chi_header(filename, data)
             _comment_prefix = ""
         elif _ext in [".txt", ".csv"]:
-            _header = cls.__create_txt_header(data, _write_x_column)
+            _header = AsciiIo.__create_txt_header(data, _write_x_column)
             if _ext == ".csv":
                 _delimiter = ","
         elif _ext == ".dat":
-            _header = cls.__create_specfile_header(filename, data, _write_x_column)
+            _header = AsciiIo.__create_specfile_header(filename, data, _write_x_column)
         else:
             raise UserConfigError(f"File extension '{_ext}' not supported for export.")
         if _write_x_column:
@@ -123,8 +133,8 @@ class AsciiIo(IoBase):
                 comments=_comment_prefix,
             )
 
-    @classmethod
-    def __create_chi_header(cls, filename: Path, data: Dataset):
+    @staticmethod
+    def __create_chi_header(filename: Path, data: Dataset) -> str:
         """
         Export data to a chi file.
 
@@ -144,7 +154,7 @@ class AsciiIo(IoBase):
         return _header
 
     @staticmethod
-    def __create_txt_header(data: Dataset, write_x_column: bool):
+    def __create_txt_header(data: Dataset, write_x_column: bool) -> str:
         """
         Export data to a text file.
 
@@ -170,7 +180,9 @@ class AsciiIo(IoBase):
         return _header
 
     @staticmethod
-    def __create_specfile_header(filename: Path, data: Dataset, write_x_column: bool):
+    def __create_specfile_header(
+        filename: Path, data: Dataset, write_x_column: bool
+    ) -> str:
         """
         Export data to a SpecFile (.dat) file.
 
@@ -181,11 +193,12 @@ class AsciiIo(IoBase):
         data : Dataset
             The data to be written to the SpecFile.
         write_x_column : bool
-            A flag which indicates whether a column with the x-axis will be written
-            (as first column).
+            A flag which indicates whether a column with the x-axis will
+            be written (as first column).
         """
-        _header = ""
-        _time = datetime.datetime.now().strftime("%a %b %d %H:%M:%S %Y")  # noqa: DTZ005
+        _time = datetime.datetime.now().strftime(  # noqa: DTZ005
+            "%a %b %d %H:%M:%S %Y"
+        )
         _ncols = (data.shape[1] if data.ndim > 1 else 1) + write_x_column
         _header = (
             f"F {Path(filename).name}\nE {time.time()}\nD {_time}\n\n"
@@ -200,38 +213,38 @@ class AsciiIo(IoBase):
             _header += f"L {data.get_data_description('(')}\n"
         return _header
 
-    @classmethod
-    def import_from_file(cls, filename: Path | str, **kwargs: Any) -> Dataset:
+    @staticmethod
+    def import_from_file(filename: Path | str, **kwargs: Any) -> Dataset:
         """
-        Read data from an Ascii file.
+        Read data from an ASCII file.
 
         The decoder is based on the extensions.
 
         Parameters
         ----------
-        filename : str | Path
+        filename : str or Path
             The filename of the file with the data to be imported.
         **kwargs : Any
             Supported arguments are:
 
-            roi : Union[tuple, None], optional
+            roi : tuple or None, optional
                 A region of interest for cropping. Acceptable are both 4-tuples
                 of integers in the format (y_low, y_high, x_low, x_high) and
                 2-tuples of integers or slice objects. If None, the full image
                 will be returned. The default is None.
-            returnType : Union[datatype, 'auto'], optional
+            astype : type or 'auto', optional
                 If 'auto', the image will be returned in its native data type.
-                If a specific datatype has been selected, the image is converted
-                to this type. The default is 'auto'.
+                If a specific datatype has been selected, the image is
+                converted to this type. The default is 'auto'.
             binning : int, optional
                 The rebinning factor to be applied to the image. The default
                 is 1.
             x_column : bool, optional
                 A flag which indicates whether the first column of the data
                 should be treated as x-axis. This flag is only used for
-                importing .dat and .csv files or .txt files without a metadata
-                header. The default is True for .dat and False for .csv and .txt
-                files.
+                importing .dat and .csv files or .txt files without a
+                metadata header. The default is True for .dat and False
+                for .csv and .txt files.
             x_column_index : int, optional
                 The column number to be used as x-column. This is only used if
                 x_column is True. The default is 0.
@@ -239,38 +252,41 @@ class AsciiIo(IoBase):
         Returns
         -------
         data : Dataset
-            The data in the form of a pydidas Dataset (with embedded metadata)
+            The data in the form of a pydidas Dataset (with embedded
+            metadata)
         """
         _ext = get_extension(filename)
         _x_column = kwargs.get("x_column", _ext in [".dat"])
         _col_no = kwargs.get("x_column_index", 0)
-        with CatchFileErrors(filename), warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
+        with (
+            CatchFileErrors(filename),
+            warnings.catch_warnings(action="ignore", category=UserWarning),
+        ):
             if _ext == ".chi":
-                cls._data = cls.__import_chi(filename)
+                _data = AsciiIo.__import_chi(filename)
             elif _ext == ".dat":
-                cls._data = cls.__import_specfile(
+                _data = AsciiIo.__import_specfile(
                     filename, _x_column, x_column_index=_col_no
                 )
             elif _ext in [".txt", ".csv"]:
                 _delimiter = "," if _ext == ".csv" else None
-                cls._data = cls.__import_txt(
+                _data = AsciiIo.__import_txt(
                     filename,
                     delimiter=_delimiter,
                     x_column=_x_column,
                     x_column_index=_col_no,
                 )
             elif _ext == ".fio":
-                cls._data = cls.__import_fio(
+                _data = AsciiIo.__import_fio(
                     filename, x_column=_x_column, x_column_index=_col_no
                 )
             elif _ext == ".asc":
-                cls._data = cls.__import_asc(filename)
+                _data = AsciiIo.__import_asc(filename)
             else:
                 raise UserConfigError(
                     f"File extension '{_ext}' not supported for import."
                 )
-        return cls.return_data(**kwargs)
+        return AsciiIo.return_data(_data, **kwargs)
 
     @staticmethod
     def __import_chi(filename: Path | str) -> Dataset:
@@ -279,7 +295,7 @@ class AsciiIo(IoBase):
 
         Parameters
         ----------
-        filename : Path |  str
+        filename : Path or str
             The filename of the chi file to be imported.
 
         Returns
@@ -298,19 +314,19 @@ class AsciiIo(IoBase):
             data_unit=_data_unit,
         )
 
-    @classmethod
+    @staticmethod
     def __import_specfile(
-        cls, filename: Path | str, x_column: bool, x_column_index: int = 0
+        filename: Path | str, x_column: bool, x_column_index: int = 0
     ) -> Dataset:
         """
         Import a SpecFile (.dat) file.
 
         Parameters
         ----------
-        filename : Path | str
+        filename : Path or str
             The filename of the SpecFile to be imported.
         x_column : bool
-            A flag which indicates whether the to read the x-axis from the data.
+            A flag which indicates whether to read the x-axis from the data.
         x_column_index : int, optional
             The column number to be used as x-column. This is only used if
             x_column is True. The default is 0.
@@ -329,7 +345,8 @@ class AsciiIo(IoBase):
         if x_column:
             if _imported_data.ndim == 1:
                 raise UserConfigError(
-                    "Cannot read x-column from 1d SPEC file. Please check the file "
+                    "Cannot read x-column from 1d SPEC file. Please check "
+                    "the file "
                     "and assure it has two columns"
                 )
             _ax_ranges: list[Any] = [_imported_data[:, x_column_index]]
@@ -338,6 +355,9 @@ class AsciiIo(IoBase):
                 _ax_ranges.append(np.arange(_imported_data.shape[1]))
         else:
             _ax_ranges = [np.arange(n) for n in _imported_data.shape]
+        _raw_x_column_metadata = (
+            {"raw_data_x_column": x_column_index} if x_column else {}
+        )
         return Dataset(
             _imported_data,
             axis_units=_units,
@@ -345,12 +365,11 @@ class AsciiIo(IoBase):
             axis_ranges=_ax_ranges,
             data_label=_data_label,
             data_unit=_data_unit,
-            metadata=({"raw_data_x_column": x_column_index} if x_column else {}),
+            metadata=_raw_x_column_metadata,
         )
 
-    @classmethod
+    @staticmethod
     def __import_txt(
-        cls,
         filename: Path | str,
         delimiter: str | None = None,
         x_column: bool = True,
@@ -361,13 +380,13 @@ class AsciiIo(IoBase):
 
         Parameters
         ----------
-        filename : Path | str
+        filename : Path or str
             The filename of the text file to be imported.
         delimiter : str, optional
             The delimiter used in the text file. The default is None which
             resolves to any whitespace.
         x_column : bool, optional
-            A flag which indicates whether the to read the x-axis from the data.
+            A flag which indicates whether to read the x-axis from the data.
         x_column_index : int, optional
             The column number (0-indexed) to be used as x-column if x_column
             is True. The default is 0.
@@ -380,7 +399,8 @@ class AsciiIo(IoBase):
         _data = np.loadtxt(filename, comments="#", delimiter=delimiter)
         if _data.ndim == 1 and x_column:
             raise UserConfigError(
-                "Cannot read x-column from 1d text file. Please check the file "
+                "Cannot read x-column from 1d text file. Please check the "
+                "file "
                 "and assure it has two columns"
             )
         _metadata = decode_txt_header(filename)
@@ -398,6 +418,9 @@ class AsciiIo(IoBase):
             _axes.append(None)
             _labels.append("")
             _units.append("")
+        _raw_x_column_metadata = (
+            {"raw_data_x_column": x_column_index} if x_column else {}
+        )
         return Dataset(
             _data,
             axis_ranges=_axes,
@@ -405,22 +428,22 @@ class AsciiIo(IoBase):
             axis_units=_units,
             data_label=_metadata.get("data_label", ""),
             data_unit=_metadata.get("data_unit", ""),
-            metadata=({"raw_data_x_column": x_column_index} if x_column else {}),
+            metadata=_raw_x_column_metadata,
         )
 
-    @classmethod
+    @staticmethod
     def __import_fio(
-        cls, filename: Path | str, x_column: bool = True, x_column_index: int = 0
+        filename: Path | str, x_column: bool = True, x_column_index: int = 0
     ) -> Dataset:
         """
         Import a .fio file.
 
         Parameters
         ----------
-        filename : Path | str
+        filename : Path or str
             The filename of the .fio file to be imported.
         x_column : bool, optional
-            A flag which indicates whether the to read the x-axis from the data.
+            A flag which indicates whether to read the x-axis from the data.
         x_column_index : int, optional
             The column number (0-indexed) to be used as x-column if
             x_column is True. The default is 0.
@@ -451,7 +474,8 @@ class AsciiIo(IoBase):
             raise ValueError("No data found in .fio file.")
         if _data.ndim == 1 and x_column:
             raise UserConfigError(
-                "Cannot read x-column from 1d .fio file. Please check the file "
+                "Cannot read x-column from 1d .fio file. Please check the "
+                "file "
                 "and assure it has two columns or disable x_column reading."
             )
         if x_column:
@@ -471,16 +495,19 @@ class AsciiIo(IoBase):
             _ax_labels.append(
                 "; ".join(f"{i}: {k}" for i, k in enumerate(_col_keys.values()))
             )
+        _raw_x_column_metadata = (
+            {"raw_data_x_column": x_column_index} if x_column else {}
+        )
         return Dataset(
             _data,
             axis_ranges=_axes,
             axis_labels=_ax_labels,
             data_label=_data_label,
-            metadata=({"raw_data_x_column": x_column_index} if x_column else {}),
+            metadata=_raw_x_column_metadata,
         )
 
-    @classmethod
-    def __import_asc(cls, filename: Path | str) -> Dataset:
+    @staticmethod
+    def __import_asc(filename: Path | str) -> Dataset:
         """
         Import an .asc file.
 
@@ -527,16 +554,14 @@ class AsciiIo(IoBase):
             data_unit=_metadata.get("YUNIT", ""),
         )
 
-    @classmethod
-    def read_metadata_from_file(
-        cls, filename: Path | str, **kwargs: Any
-    ) -> dict[str, Any]:
+    @staticmethod
+    def read_metadata_from_file(filename: Path | str, **kwargs: Any) -> dict[str, Any]:
         """
         Read only the metadata from an ASCII file.
 
         Parameters
         ----------
-        filename : Path | str
+        filename : Path or str
             The filename of the file with the data to be imported.
         **kwargs : Any
             Currently not used but included for consistency.
@@ -547,29 +572,27 @@ class AsciiIo(IoBase):
             A dictionary with any found metadata keys.
         """
         _ext = get_extension(filename)
-        if _ext not in cls.extensions_import:
+        if _ext not in AsciiIo.extensions_import:
             raise UserConfigError(
                 f"File extension '{_ext}' not supported for import: Cannot read "
                 "the metadata from the file."
             )
-        with (
-            CatchFileErrors(filename),
-            warnings.catch_warnings(),
-            open(filename, "r") as f,
-        ):
+        _lines: list[str] = []
+        with CatchFileErrors(filename), warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
-            _lines = f.readlines()
+            with open(filename, "r") as f:
+                _lines = f.readlines()
         if _ext == ".chi":
-            _metadata = cls.__read_chi_metadata(_lines)
-        elif _ext == ".dat":
-            _metadata = cls.__read_specfile_metadata(_lines)
-        elif _ext in [".txt", ".csv"]:
-            _metadata = cls.__read_txt_metadata(_lines)
-        elif _ext == ".fio":
-            _metadata = cls.__read_fio_metadata(_lines)
-        elif _ext == ".asc":
-            _metadata = cls.__read_asc_metadata(_lines)
-        return _metadata
+            return AsciiIo.__read_chi_metadata(_lines)
+        if _ext == ".dat":
+            return AsciiIo.__read_specfile_metadata(_lines)
+        if _ext in [".txt", ".csv"]:
+            return AsciiIo.__read_txt_metadata(_lines)
+        if _ext == ".fio":
+            return AsciiIo.__read_fio_metadata(_lines)
+        if _ext == ".asc":
+            return AsciiIo.__read_asc_metadata(_lines)
+        return {}
 
     @staticmethod
     def __read_chi_metadata(lines: list[str]) -> dict[str, Any]:
@@ -698,8 +721,8 @@ class AsciiIo(IoBase):
                         _line = lines.pop(0).strip()
                         _i = int(_line.removeprefix("Col").split()[0])
                         _line += (
-                            "    [note: in Python indexing, this column is indexed "
-                            f"as #{_i - 1}]"
+                            "    [note: in Python indexing, this column is "
+                            f"indexed as #{_i - 1}]"
                         )
                         _metadata["data_columns"].append(_line)
         except (IndexError, ValueError) as error:

--- a/src/pydidas/data_io/implementations/fabio_io.py
+++ b/src/pydidas/data_io/implementations/fabio_io.py
@@ -45,8 +45,8 @@ class FabioIo(IoBase):
     format_name: ClassVar[str] = "FabIO reader"
     dimensions: ClassVar[list[int]] = [2]
 
-    @classmethod
-    def import_from_file(cls, filename: Path | str, **kwargs: Any):
+    @staticmethod
+    def import_from_file(filename: Path | str, **kwargs: Any) -> Dataset:
         """
         Read an image from a FabIO-supported file format.
 
@@ -63,7 +63,7 @@ class FabioIo(IoBase):
                 4-tuples of integers in the format (y_low, y_high, x_low,
                 x_high) and 2-tuples of integers or slice objects.
                 If None, the full image will be returned. The default is None.
-            returnType : datatype or 'auto', optional
+            astype : datatype or 'auto', optional
                 If 'auto', the image will be returned in its native data
                 type. If a specific datatype has been selected, the image
                 is converted to this type. The default is 'auto'.
@@ -80,5 +80,5 @@ class FabioIo(IoBase):
             _data = _file.data
             _header = _file.header
 
-        cls._data = Dataset(_data, metadata=_header)
-        return cls.return_data(**kwargs)
+        _data = Dataset(_data, metadata=_header)
+        return FabioIo.return_data(_data, **kwargs)

--- a/src/pydidas/data_io/implementations/hdf5_io.py
+++ b/src/pydidas/data_io/implementations/hdf5_io.py
@@ -34,11 +34,15 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 import h5py
-from numpy import ndarray, squeeze
+from numpy import ndarray
 
 from pydidas.core import Dataset, FileReadError, UserConfigError
 from pydidas.core.constants import HDF5_EXTENSIONS
-from pydidas.core.utils import CatchFileErrors, str_repr_of_slice
+from pydidas.core.utils import (
+    CatchFileErrors,
+    str_repr_of_slice,
+    verify_is_new_file_or_replace_set,
+)
 from pydidas.core.utils.converters import convert_to_slice
 from pydidas.core.utils.hdf5 import (
     nxs_write_nxdata,
@@ -54,8 +58,8 @@ class Hdf5Io(IoBase):
     format_name: ClassVar[str] = "Hdf5"
     dimensions: ClassVar[list[int]] = [1, 2, 3, 4, 5, 6, 7, 8]
 
-    @classmethod
-    def import_from_file(cls, filename: Path | str, **kwargs: Any) -> Dataset:
+    @staticmethod
+    def import_from_file(filename: Path | str, **kwargs: Any) -> Dataset:
         """
         Read data from an Hdf5 file.
 
@@ -82,7 +86,7 @@ class Hdf5Io(IoBase):
                 x_low, x_high) or 2-tuples of integers or slice
                 objects. If None, the full image will be returned. The
                 default is None.
-            returnType : type or 'auto', optional
+            astype : type or 'auto', optional
                 If 'auto', the image will be returned in its native data
                 type. If a specific datatype has been selected, the image
                 is converted to this type. The default is 'auto'.
@@ -98,7 +102,7 @@ class Hdf5Io(IoBase):
 
         Returns
         -------
-        data : pydidas.core.Dataset
+        data : Dataset
             The data in the form of a pydidas Dataset (with embedded
             metadata)
         """
@@ -130,30 +134,36 @@ class Hdf5Io(IoBase):
                 )
             _data = Dataset(
                 _raw_data,
-                metadata={"indices": _human_readable_indices, "dataset": dataset},
+                metadata={
+                    "indices": _human_readable_indices,
+                    "dataset": dataset,
+                },
             )
             if kwargs.get("import_metadata", True):
-                cls._update_dataset_metadata(_data, _h5file, dataset, _indices)
-                # TODO [future]: deprecate the axes group reading from legacy results
-                cls.__read_legacy_metadata(_data, _h5file, dataset, _indices)
+                Hdf5Io._update_dataset_metadata(_data, _h5file, dataset, _indices)
+                # TODO [future]: deprecate the axes group reading from
+                # legacy results
+                Hdf5Io.__read_legacy_metadata(_data, _h5file, dataset, _indices)
             if auto_squeeze:
-                _data = squeeze(_data)
-            cls._data = _data
-        return cls.return_data(**kwargs)
+                _data = _data.squeeze()
+        return Hdf5Io.return_data(_data, **kwargs)
 
     @staticmethod
     def _update_dataset_metadata(
-        data: Dataset, h5file: h5py.File, dataset: str, slicing_indices: tuple[slice]
+        data: Dataset,
+        h5file: h5py.File,
+        dataset: str,
+        slicing_indices: tuple[slice, ...],
     ) -> None:
         """
-        Check the hdf5 file for Dataset metadata and update the data's properties.
+        Check the hdf5 file for Dataset metadata and update its properties.
 
-        This method reads NeXus-compliant metadata from the hdf5 file and updates
-        the Dataset's axis labels, units, and ranges accordingly.
+        This method reads NeXus-compliant metadata from the hdf5 file and
+        updates the Dataset's axis labels, units, and ranges accordingly.
 
         Parameters
         ----------
-        data : pydidas.core.Dataset
+        data : Dataset
             The Dataset with the raw data.
         h5file : h5py.File
             The open h5py file object.
@@ -203,14 +213,17 @@ class Hdf5Io(IoBase):
 
     @staticmethod
     def __read_legacy_metadata(
-        data: Dataset, h5file: h5py.File, dataset: str, slicing_indices: tuple[slice]
+        data: Dataset,
+        h5file: h5py.File,
+        dataset: str,
+        slicing_indices: tuple[slice, ...],
     ) -> None:
         """
         Read legacy metadata from hdf5 files.
 
         Parameters
         ----------
-        data : pydidas.core.Dataset
+        data : Dataset
             The Dataset with the raw data.
         h5file : h5py.File
             The open h5py file object.
@@ -256,8 +269,8 @@ class Hdf5Io(IoBase):
             if _key in h5file[_root] and getattr(data, _key) == "":
                 setattr(data, _key, h5file[_root][_key][()].decode())
 
-    @classmethod
-    def export_to_file(cls, filename: Path | str, data: ndarray, **kwargs: Any) -> None:
+    @staticmethod
+    def export_to_file(filename: Path | str, data: ndarray, **kwargs: Any) -> None:
         """
         Export data to an Hdf5 file.
 
@@ -277,9 +290,9 @@ class Hdf5Io(IoBase):
                 Flag to allow overwriting of existing files. The default
                 is False.
         """
-        cls.check_for_existing_file(filename, **kwargs)
+        verify_is_new_file_or_replace_set(filename, **kwargs)
         _dataset = kwargs.get("dataset", "entry/data/data")
-        _data_group_name, _dset_name = os.path.split(_dataset)
+        _data_group_name = os.path.dirname(_dataset)
         _root_group_name = os.path.dirname(_data_group_name)
         if _root_group_name == "":
             raise UserConfigError(
@@ -290,4 +303,4 @@ class Hdf5Io(IoBase):
         if not isinstance(data, Dataset):
             data = Dataset(data)
         with h5py.File(filename, "w") as _file:
-            _data_group = nxs_write_nxdata(_file, _dataset, data)
+            nxs_write_nxdata(_file, _dataset, data)

--- a/src/pydidas/data_io/implementations/io_base.py
+++ b/src/pydidas/data_io/implementations/io_base.py
@@ -30,7 +30,7 @@ __all__ = ["IoBase"]
 
 from numbers import Integral
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from numpy import amax, amin, ndarray
 
@@ -54,8 +54,8 @@ class IoBase(metaclass=IoManager):
     _roi_controller: ClassVar[RoiSliceManager] = RoiSliceManager()
     _data = None
 
-    @classmethod
-    def export_to_file(cls, filename: Path | str, data: ndarray, **kwargs: dict):
+    @staticmethod
+    def export_to_file(filename: Path | str, data: ndarray, **kwargs: Any) -> None:
         """
         Write the content to a file.
 
@@ -68,14 +68,14 @@ class IoBase(metaclass=IoManager):
         data : ndarray
             The data to be written to the file. Pydidas Dataset objects will
             also export their metadata if the file format allows it.
-        **kwargs : dict
+        **kwargs : Any
             Any keyword arguments. Supported keywords must be specified by
             the specific implementation.
         """
         raise NotImplementedError
 
-    @classmethod
-    def import_from_file(cls, filename: Path | str, **kwargs: dict) -> Dataset:
+    @staticmethod
+    def import_from_file(filename: Path | str, **kwargs: Any) -> Dataset:
         """
         Restore the content from a file
 
@@ -83,47 +83,77 @@ class IoBase(metaclass=IoManager):
 
         Parameters
         ----------
-        filename: Path or str
+        filename : Path or str
             The filename of the data file to be imported.
+        **kwargs : Any
+            Any keyword arguments. Supported keywords must be specified by
+            the specific implementation.
         """
         raise NotImplementedError
 
-    @classmethod
-    def check_for_existing_file(cls, filename: Path | str, **kwargs: dict):
+    @staticmethod
+    def return_data(data: Dataset, **kwargs: Any) -> Dataset:
         """
-        Check if the file exists and if the overwrite flag has been set.
+        Return the stored data.
 
         Parameters
         ----------
-        filename: Path or str
-            The full filename and path.
-        **kwargs : dict
-            Any keyword arguments. Supported is 'overwrite' [bool], a flag to allow
-            overwriting of existing files.
+        data : Dataset
+            The data to be returned.
+        **kwargs : Any
+            A dictionary of keyword arguments. Supported keyword arguments
+            are:
+
+            astype : type or 'auto', optional
+                The datatype to which the data should be converted. If
+                "auto", the data will be returned in its native datatype.
+                The default is "auto".
+            binning : int, optional
+                The rebinning factor to be applied to the data. The default
+                is 1.
+            roi : tuple or None, optional
+                A region of interest for cropping. Acceptable are both 4-tuples
+                of integers in the format (y_low, y_high, x_low, x_high)
+                and 2-tuples of integers or slice objects. If None, the full
+                image will be returned. The default is None.
 
         Raises
         ------
-        FileExistsError
-            If a file with a filename exists and the overwrite flag is not True.
-        """
-        _overwrite = kwargs.get("overwrite", False)
-        if Path(filename).exists() and not _overwrite:
-            raise FileExistsError(
-                f"The file `{filename}` exists and overwriting has not been confirmed."
-            )
+        ValueError
+            If no data has been read.
 
-    @classmethod
-    def get_data_range(cls, data: Dataset, **kwargs: dict):
+        Returns
+        -------
+        data : Dataset
+            The data in the form of a pydidas Dataset.
+        """
+        _return_type = kwargs.get("astype", "auto")
+        _local_roi = kwargs.get("roi", None)
+        _binning = kwargs.get("binning", 1)
+        if data is None:
+            raise ValueError("No image has been read.")
+        if _local_roi is not None:
+            IoBase._roi_controller.ndim = kwargs.get("ndim", 2)
+            IoBase._roi_controller.roi = _local_roi
+            data = data[IoBase._roi_controller.roi]
+        if _binning != 1:
+            data = rebin(data, int(_binning))
+        if _return_type not in ("auto", data.dtype):
+            data = data.astype(_return_type)
+        return data
+
+    @staticmethod
+    def get_data_range(data: ndarray, **kwargs: Any) -> list:
         """
         Get the data range from the keyword arguments or the data values.
 
         Parameters
         ----------
-        data : pydidas.core.Dataset
-            The data to be exported.
-        **kwargs : dict
-            The keyword arguments. This method will only use the "data_range"
-            keyword.
+        data : np.ndarray
+            The data to be inspected.
+        **kwargs : Any
+            The keyword arguments. This method will only use the
+            `data_range` keyword.
 
         Returns
         -------
@@ -138,49 +168,8 @@ class IoBase(metaclass=IoManager):
             _range[1] = amax(data)
         return _range
 
-    @classmethod
-    def return_data(cls, **kwargs: dict) -> Dataset:
-        """
-        Return the stored data.
-
-        Parameters
-        ----------
-        **kwargs : dict
-            A dictionary of keyword arguments. Supported keyword arguments
-            are: "datatype", "binning", "roi".
-
-            "datatype" can be either "auto" for the native datatype or the
-            specified type. "Binning" can be any integer number, and "roi" can
-            be either None or a 4-tuple of float.
-
-        Raises
-        ------
-        ValueError
-            If no data has been read.
-
-        Returns
-        -------
-        _data : pydidas.core.Dataset
-            The data in the form of a pydidas Dataset (a subclassed numpy.ndarray).
-        """
-        _return_type = kwargs.get("datatype", "auto")
-        _local_roi = kwargs.get("roi", None)
-        _binning = kwargs.get("binning", 1)
-        if cls._data is None:
-            raise ValueError("No image has been read.")
-        _data = cls._data
-        if _local_roi is not None:
-            cls._roi_controller.ndim = kwargs.get("ndim", 2)
-            cls._roi_controller.roi = _local_roi
-            _data = _data[cls._roi_controller.roi]
-        if _binning != 1:
-            _data = rebin(_data, int(_binning))
-        if _return_type not in ("auto", _data.dtype):
-            _data = _data.astype(_return_type)
-        return _data
-
     @staticmethod
-    def raise_filereaderror_from_exception(ex: Exception, filename: str):
+    def raise_filereaderror_from_exception(ex: Exception, filename: str) -> None:
         """
         Raise a FileReadError from the given Exception.
 

--- a/src/pydidas/data_io/implementations/io_exporter_matplotlib.py
+++ b/src/pydidas/data_io/implementations/io_exporter_matplotlib.py
@@ -15,10 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Module with the IoExporterMatplotlib class for exporting data in form of matplotlib
-images.
-"""
+"""Module with the IoExporterMatplotlib class for matplotlib-based exports."""
 
 __author__ = "Malte Storm"
 __copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
@@ -29,11 +26,12 @@ __all__ = []
 
 
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import numpy as np
 
 from pydidas.core import Dataset
+from pydidas.core.utils import verify_is_new_file_or_replace_set
 from pydidas.data_io.implementations.io_base import IoBase
 from pydidas.data_io.utils import calculate_fig_size_arguments
 
@@ -46,33 +44,33 @@ class IoExporterMatplotlib(IoBase):
     format_name: ClassVar[str] = ""
     dimensions: ClassVar[list[int]] = [1, 2]
 
-    @classmethod
-    def export_to_file(cls, filename: Path | str, data: np.ndarray, **kwargs: dict):
+    @staticmethod
+    def export_to_file(filename: Path | str, data: np.ndarray, **kwargs: Any) -> None:
         """
         Export data as a matplotlib plot.
 
         Parameters
         ----------
-        filename : Union[pathlib.Path, str]
+        filename : Path or str
             The filename
         data : np.ndarray
             The data to be written to file.
         """
         if data.ndim == 1:
-            cls.export_matplotlib_plot(filename, data, **kwargs)
+            IoExporterMatplotlib.export_matplotlib_plot(filename, data, **kwargs)
         else:
-            cls.export_matplotlib_figure(filename, data, **kwargs)
+            IoExporterMatplotlib.export_matplotlib_figure(filename, data, **kwargs)
 
-    @classmethod
+    @staticmethod
     def export_matplotlib_figure(
-        cls, filename: Path | str, data: np.ndarray, **kwargs: dict
-    ):
+        filename: Path | str, data: np.ndarray, **kwargs: Any
+    ) -> None:
         """
         Export data to a matplotlib file.
 
         Parameters
         ----------
-        filename : Union[pathlib.Path, str]
+        filename : Path or str
             The filename
         data : np.ndarray
             The data to be written to file.
@@ -84,19 +82,22 @@ class IoExporterMatplotlib(IoBase):
         data_range : list, optional
             The range with lower and upper bounds for the data export.
         """
-        cls.check_for_existing_file(filename, **kwargs)
+        verify_is_new_file_or_replace_set(filename, **kwargs)
         import matplotlib.pyplot as plt
 
-        _range = cls.get_data_range(data, **kwargs)
+        _data_range = IoExporterMatplotlib.get_data_range(data, **kwargs)
         _cmap = kwargs.get("colormap", "gray")
         _backend = plt.get_backend()
         try:
             plt.rcParams["backend"] = "Agg"
             _figshape, _dpi = calculate_fig_size_arguments(data.shape)
-            fig1 = plt.figure(figsize=_figshape, dpi=50)
-            ax = fig1.add_axes([0, 0, 1, 1])
+            fig1, ax = plt.subplots(figsize=_figshape, dpi=50)
             ax.imshow(
-                data, interpolation="none", vmin=_range[0], vmax=_range[1], cmap=_cmap
+                data,
+                interpolation="none",
+                vmin=_data_range[0],
+                vmax=_data_range[1],
+                cmap=_cmap,
             )
             ax.set_xticks([])
             ax.set_yticks([])
@@ -105,32 +106,32 @@ class IoExporterMatplotlib(IoBase):
         finally:
             plt.rcParams["backend"] = _backend
 
-    @classmethod
+    @staticmethod
     def export_matplotlib_plot(
-        cls, filename: Path | str, data: np.ndarray, **kwargs: dict
-    ):
+        filename: Path | str, data: np.ndarray, **kwargs: Any
+    ) -> None:
         """
         Export data to a matplotlib file.
 
         Parameters
         ----------
-        filename : Union[pathlib.Path, str]
+        filename : Path or str
             The filename
         data : np.ndarray
             The data to be written to file.
         overwrite : bool, optional
             Flag to allow overwriting of existing files. The default is False.
         """
-        cls.check_for_existing_file(filename, **kwargs)
+        verify_is_new_file_or_replace_set(filename, **kwargs)
         import matplotlib.pyplot as plt
 
-        _range = cls.get_data_range(data, **kwargs)
+        _data_range = IoExporterMatplotlib.get_data_range(data, **kwargs)
         _backend = plt.get_backend()
         try:
             plt.rcParams["backend"] = "Agg"
-            _figshape, _dpi = calculate_fig_size_arguments(data.shape)
-            fig1 = plt.figure(figsize=_figshape, dpi=50)
-            ax = fig1.add_axes([0, 0, 1, 1])
+            # artifically set the size to a 60:100 ratio for 1D plots
+            _figshape, _dpi = calculate_fig_size_arguments((60, 100))
+            fig1, ax = plt.subplots(figsize=_figshape, dpi=50)
 
             _x = (
                 data.axis_ranges[0]
@@ -138,7 +139,8 @@ class IoExporterMatplotlib(IoBase):
                 else np.arange(data.size)
             )
 
-            ax.plot(_x, data, vmin=_range[0], vmax=_range[1])
+            ax.plot(_x, data)
+            ax.set_ylim(*_data_range)
             fig1.savefig(filename, dpi=_dpi)
             plt.close(fig1)
         finally:

--- a/src/pydidas/data_io/implementations/io_exporter_matplotlib.py
+++ b/src/pydidas/data_io/implementations/io_exporter_matplotlib.py
@@ -91,7 +91,8 @@ class IoExporterMatplotlib(IoBase):
         try:
             plt.rcParams["backend"] = "Agg"
             _figshape, _dpi = calculate_fig_size_arguments(data.shape)
-            fig1, ax = plt.subplots(figsize=_figshape, dpi=50)
+            fig1 = plt.figure(figsize=_figshape, dpi=50)
+            ax = fig1.add_axes([0, 0, 1, 1])
             ax.imshow(
                 data,
                 interpolation="none",
@@ -129,7 +130,7 @@ class IoExporterMatplotlib(IoBase):
         _backend = plt.get_backend()
         try:
             plt.rcParams["backend"] = "Agg"
-            # artifically set the size to a 60:100 ratio for 1D plots
+            # artificially set the size to a 60:100 ratio for 1D plots
             _figshape, _dpi = calculate_fig_size_arguments((60, 100))
             fig1, ax = plt.subplots(figsize=_figshape, dpi=50)
 

--- a/src/pydidas/data_io/implementations/jpeg_io.py
+++ b/src/pydidas/data_io/implementations/jpeg_io.py
@@ -26,6 +26,7 @@ __maintainer__ = "Malte Storm"
 __status__ = "Production"
 __all__ = []
 
+
 from typing import ClassVar
 
 from pydidas.core.constants import JPG_EXTENSIONS

--- a/src/pydidas/data_io/implementations/numpy_io.py
+++ b/src/pydidas/data_io/implementations/numpy_io.py
@@ -34,7 +34,10 @@ import numpy as np
 
 from pydidas.core import Dataset
 from pydidas.core.constants import NUMPY_EXTENSIONS
-from pydidas.core.utils import CatchFileErrors
+from pydidas.core.utils import (
+    CatchFileErrors,
+    verify_is_new_file_or_replace_set,
+)
 from pydidas.data_io.implementations.io_base import IoBase
 
 
@@ -46,28 +49,28 @@ class NumpyIo(IoBase):
     format_name: ClassVar[str] = "Numpy"
     dimensions: ClassVar[list[int]] = [1, 2, 3, 4, 5, 6]
 
-    @classmethod
-    def import_from_file(cls, filename: Path | str, **kwargs: Any):
+    @staticmethod
+    def import_from_file(filename: Path | str, **kwargs: Any) -> Dataset:
         """
         Read data from a numpy file.
 
         Parameters
         ----------
-        filename : Path | str
+        filename : Path or str
             The filename of the file with the data to be imported.
         **kwargs : Any
             Any keyword arguments. These will be passed to the implemented
             importer. Supported arguments are:
 
-            roi : Union[tuple, None], optional
+            roi : tuple or None, optional
                 A region of interest for cropping. Acceptable are both 4-tuples
                 of integers in the format (y_low, y_high, x_low, x_high) and
                 2-tuples of integers or slice objects. If None, the full image
                 will be returned. The default is None.
-            returnType : Union[datatype, 'auto'], optional
+            astype : type or 'auto', optional
                 If 'auto', the image will be returned in its native data type.
-                If a specific datatype has been selected, the image is converted
-                to this type. The default is 'auto'.
+                If a specific datatype has been selected, the image is
+                converted to this type. The default is 'auto'.
             binning : int, optional
                 The rebinning factor to be applied to the image. The default
                 is 1.
@@ -75,21 +78,21 @@ class NumpyIo(IoBase):
         Returns
         -------
         data : pydidas.core.Dataset
-            The data in the form of a pydidas Dataset (with embedded metadata)
+            The data in the form of a pydidas Dataset (with embedded
+            metadata)
         """
         with CatchFileErrors(filename, EOFError):
-            _data = np.squeeze(np.load(filename))
-        cls._data = Dataset(_data)
-        return cls.return_data(**kwargs)
+            _data = Dataset(np.squeeze(np.load(filename)))
+        return NumpyIo.return_data(_data, **kwargs)
 
-    @classmethod
-    def export_to_file(cls, filename: Path | str, data: np.ndarray, **kwargs: Any):
+    @staticmethod
+    def export_to_file(filename: Path | str, data: np.ndarray, **kwargs: Any) -> None:
         """
         Export data to a numpy file.
 
         Parameters
         ----------
-        filename : Path | str
+        filename : Path or str
             The filename
         data : np.ndarray
             The data to be written to file.
@@ -97,7 +100,8 @@ class NumpyIo(IoBase):
             Supported keyword arguments are:
 
             overwrite : bool, optional
-                Flag to allow overwriting of existing files. The default is False.
+                Flag to allow overwriting of existing files. The default
+                is False.
         """
-        cls.check_for_existing_file(filename, **kwargs)
+        verify_is_new_file_or_replace_set(filename, **kwargs)
         np.save(filename, data)

--- a/src/pydidas/data_io/implementations/raw_io.py
+++ b/src/pydidas/data_io/implementations/raw_io.py
@@ -29,13 +29,16 @@ __all__ = []
 
 
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import numpy as np
 
-from pydidas.core import Dataset
+from pydidas.core import Dataset, UserConfigError
 from pydidas.core.constants import BINARY_EXTENSIONS
-from pydidas.core.utils import CatchFileErrors
+from pydidas.core.utils import (
+    CatchFileErrors,
+    verify_is_new_file_or_replace_set,
+)
 from pydidas.data_io.implementations.io_base import IoBase
 
 
@@ -47,34 +50,28 @@ class RawIo(IoBase):
     format_name: ClassVar[str] = "Raw binary"
     dimensions: ClassVar[list[int]] = [1, 2, 3, 4, 5, 6]
 
-    @classmethod
-    def import_from_file(
-        cls,
-        filename: Path | str,
-        datatype: None | type,
-        shape: tuple = (),
-        **kwargs: dict,
-    ) -> Dataset:
+    @staticmethod
+    def import_from_file(filename: Path | str, **kwargs: Any) -> Dataset:
         """
         Read data from a raw binary data without a header.
 
         Parameters
         ----------
-        filename : Union[pathlib.Path, str]
+        filename : Path or str
             The filename of the file with the data to be imported.
-        datatype : object
+        datatype : type
             The python datatype used for decoding the bit-information of the
             binary file. The default is None which will raise an exception.
-        shape : Union[tuple, list]
+        shape : tuple or list
             The shape of the raw data to be imported. This keyword must be
             used to allow a correct shaping of the raw data. If the shape is
             empty, an Exception will be raised. The default is [].
-        roi : Union[tuple, None], optional
+        roi : tuple or None, optional
             A region of interest for cropping. Acceptable are both 4-tuples
             of integers in the format (y_low, y_high, x_low, x_high) as well
             as 2-tuples of integers or slice objects. If None, the full image
             will be returned. The default is None.
-        returnType : Union[datatype, 'auto'], optional
+        astype : type or 'auto', optional
             If 'auto', the image will be returned in its native data type.
             If a specific datatype has been selected, the image is converted
             to this type. The default is 'auto'.
@@ -87,37 +84,44 @@ class RawIo(IoBase):
 
         Returns
         -------
-        data : pydidas.core.Dataset
+        data : Dataset
             The data in form of a pydidas Dataset (with embedded metadata)
         """
-        if datatype is None:
-            raise KeyError("The datatype has not been specified.")
+        _dtype = kwargs.get("datatype")
+        if _dtype is None:
+            raise UserConfigError(
+                "The datatype must be specified when importing raw binary data."
+            )
+        _shape = kwargs.get("shape", [])
+        if not _shape:
+            raise UserConfigError(
+                "The shape must be specified when importing raw binary data."
+            )
         _offset = kwargs.get("offset", 0)
         with CatchFileErrors(filename):
-            _data = np.fromfile(filename, dtype=datatype, offset=_offset)
-        if _data.size != np.prod(shape):
-            cls.raise_filereaderror_from_exception(
+            _data = np.fromfile(filename, dtype=_dtype, offset=_offset)
+        if _data.size != np.prod(_shape):
+            RawIo.raise_filereaderror_from_exception(
                 ValueError("The given shape does not match the data size."),
                 str(filename),
             )
-        cls._data = Dataset(_data.reshape(shape))
-        return cls.return_data(**kwargs)
+        _data = Dataset(_data.reshape(_shape))
+        return RawIo.return_data(_data, **kwargs)
 
-    @classmethod
-    def export_to_file(cls, filename: Path | str, data: np.ndarray, **kwargs: dict):
+    @staticmethod
+    def export_to_file(filename: Path | str, data: np.ndarray, **kwargs: Any) -> None:
         """
         Export data to raw binary file without a header.
 
         Parameters
         ----------
-        filename : Union[pathlib.Path, str]
+        filename : Path or str
             The filename
         data : np.ndarray
             The data to be written to file.
         overwrite : bool, optional
             Flag to allow overwriting of existing files. The default is False.
-
         """
-        cls.check_for_existing_file(filename, **kwargs)
+        verify_is_new_file_or_replace_set(filename, **kwargs)
         with open(filename, "wb") as _file:
             data.tofile(_file)

--- a/src/pydidas/data_io/implementations/tiff_io.py
+++ b/src/pydidas/data_io/implementations/tiff_io.py
@@ -29,13 +29,14 @@ __all__ = []
 
 import warnings
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import numpy as np
 
 from pydidas.core import Dataset
 from pydidas.core.constants import TIFF_EXTENSIONS
-from pydidas.core.utils import CatchFileErrors
+from pydidas.core.lazy_imports.skimage import TiffFileError, imread, imsave
+from pydidas.core.utils import CatchFileErrors, verify_is_new_file_or_replace_set
 from pydidas.data_io.implementations.io_base import IoBase
 
 
@@ -47,24 +48,24 @@ class TiffIo(IoBase):
     format_name: ClassVar[str] = "Tiff"
     dimensions: ClassVar[list[int]] = [2]
 
-    @classmethod
-    def import_from_file(cls, filename: Path | str, **kwargs: dict) -> Dataset:
+    @staticmethod
+    def import_from_file(filename: Path | str, **kwargs: Any) -> Dataset:
         """
         Read data from a tiff file.
 
         Parameters
         ----------
-        filename : Union[pathlib.Path, str]
+        filename : Path or str
             The filename of the file with the data to be imported.
-        **kwargs : dict
+        **kwargs : Any
             Supported arguments are:
 
-            roi : Union[tuple, None], optional
+            roi : tuple or None, optional
                 A region of interest for cropping. Acceptable are both 4-tuples
                 of integers in the format (y_low, y_high, x_low, x_high) and
                 2-tuples of integers or slice objects. If None, the full image
                 will be returned. The default is None.
-            returnType : Union[datatype, 'auto'], optional
+            astype : type or 'auto', optional
                 If 'auto', the image will be returned in its native data type.
                 If a specific datatype has been selected, the image is converted
                 to this type. The default is 'auto'.
@@ -74,21 +75,19 @@ class TiffIo(IoBase):
 
         Returns
         -------
-        data : pydidas.core.Dataset
+        data : Dataset
             The data in the form of a pydidas Dataset (with embedded metadata)
         """
-        from skimage.io import imread
-        from tifffile import TiffFileError
-
-        with CatchFileErrors(filename, TiffFileError), warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
+        with (
+            CatchFileErrors(filename, TiffFileError),
+            warnings.catch_warnings(action="ignore", category=UserWarning),
+        ):
             _data = imread(filename)
+            _data = Dataset(_data)
+        return TiffIo.return_data(_data, **kwargs)
 
-        cls._data = Dataset(_data)
-        return cls.return_data(**kwargs)
-
-    @classmethod
-    def export_to_file(cls, filename: Path | str, data: np.ndarray, **kwargs: dict):
+    @staticmethod
+    def export_to_file(filename: Path | str, data: np.ndarray, **kwargs: Any) -> None:
         """
         Export data to a tiff file.
 
@@ -101,22 +100,19 @@ class TiffIo(IoBase):
 
         Parameters
         ----------
-        filename : Union[pathlib.Path, str]
+        filename : Path or str
             The filename
         data : np.ndarray
             The data to be written to file.
-        **kwargs : dict
+        **kwargs : Any
             Supported arguments are:
 
             overwrite : bool, optional
-                Flag to allow overwriting of existing files. The default is False.
-
+                Flag to allow overwriting of existing files. The default is
+                False.
         """
-        cls.check_for_existing_file(filename, **kwargs)
-        from skimage.io import imsave
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
+        verify_is_new_file_or_replace_set(filename, **kwargs)
+        with warnings.catch_warnings(action="ignore", category=UserWarning):
             if data.dtype.type in [np.float64, np.longdouble]:
                 imsave(filename, data.astype(np.float32))
             else:

--- a/src/pydidas/gui/frames/image_math_frame.py
+++ b/src/pydidas/gui/frames/image_math_frame.py
@@ -156,7 +156,7 @@ class ImageMathFrame(BaseFrame):
                 f"::{self.get_param_value('hdf5_key', dtype=str)}"
                 f"::{self.get_param_value('hdf5_frame')}"
             )
-        open_kwargs["datatype"] = np.float32
+        open_kwargs["astype"] = np.float32
         self._input["data"] = import_data(filename, **open_kwargs)
         self._input["name"] = _fname
         self._input["path"] = filename

--- a/tests/data_io/implementations/test_ascii_io.py
+++ b/tests/data_io/implementations/test_ascii_io.py
@@ -30,6 +30,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from tests.data_io.implementations.test_io_base import IoBaseTests
+
 from pydidas.core import Dataset, FileReadError, UserConfigError
 from pydidas.data_io.implementations.ascii_io import AsciiIo
 
@@ -44,7 +46,7 @@ _test_data = Dataset(
     axis_units=["deg"],
     data_label="test data",
     data_unit="counts",
-    metadata={"test_metadata": 42, "creator": "pytest"},
+    metadata={"test_metadata": 42, "creator": "pytest", "float_item": -1.5},
 )
 
 _TEST_DIR = Path(__file__).parents[2] / "_data"
@@ -99,6 +101,15 @@ def get_data_with_ncols(ncols):
     _properties["axis_units"][1] = ""
     _properties["axis_ranges"][1] = np.arange(ncols)
     return Dataset(_new, **_properties)
+
+
+@pytest.fixture
+def io_class():
+    return AsciiIo
+
+
+class TestAsciiIo(IoBaseTests):
+    """Runs the generic IoBase tests against AsciiIo."""
 
 
 def test_export_to_file__higher_data_dim(temp_path):
@@ -645,6 +656,19 @@ def test_read_metadata_from_file__specfile__corrupt_header(temp_path):
         f.write("#N ab\n1 2 3\n4 5 6\n7 8 9\n")
     with pytest.raises(UserConfigError):
         _metadata = AsciiIo.read_metadata_from_file(temp_path / "test.dat")
+
+
+def test_read_metadata_from_file__txt_wo_metadata(temp_path):
+    _fname = temp_path / "test.txt"
+    _data = _test_data.copy()
+    _data.metadata = {}
+    AsciiIo.export_to_file(_fname, _data, x_column=True, overwrite=True)
+    with open(_fname, "r+") as f:
+        _lines = [l for l in f if l != "'# Metadata:\n'"]
+    with open(_fname, "w") as f:
+        f.writelines(_lines)
+    _metadata = AsciiIo.read_metadata_from_file(_fname)
+    assert "metadata" not in _metadata
 
 
 @pytest.mark.parametrize("ncols", [1, 2, 3])

--- a/tests/data_io/implementations/test_ascii_io.py
+++ b/tests/data_io/implementations/test_ascii_io.py
@@ -635,15 +635,15 @@ def test_read_metadata_from_file__chi(temp_path):
 def test_read_metadata_from_file__specfile(temp_path):
     _fname = temp_path / "test.dat"
     _epoch = time.time()
-    _datetime = datetime.datetime.now()  # noqa DTZ005
+    _dt = datetime.datetime.now()  # noqa DTZ005
     AsciiIo.export_to_file(_fname, _test_data, x_column=True, overwrite=True)
     _metadata = AsciiIo.read_metadata_from_file(_fname)
+    _delta = (
+        _dt - datetime.datetime.strptime(_metadata["date"], "%a %b %d %H:%M:%S %Y")  # noqa DTZ007
+    )
     assert _metadata["filename"] == _fname.name
     assert _metadata["epoch"] - _epoch < 5  # within 5 seconds
-    assert (
-        _datetime
-        - datetime.datetime.strptime(_metadata["date"], "%a %b %d %H:%M:%S %Y")  # noqa DTZ007
-    ).seconds < 5
+    assert abs(_delta.total_seconds()) < 5
     assert _metadata["n_columns"] == 2
     assert _metadata["scan_title"] == "1 pydidas results"
     assert _metadata["labels"] == _test_data.get_axis_description(
@@ -664,7 +664,7 @@ def test_read_metadata_from_file__txt_wo_metadata(temp_path):
     _data.metadata = {}
     AsciiIo.export_to_file(_fname, _data, x_column=True, overwrite=True)
     with open(_fname, "r+") as f:
-        _lines = [l for l in f if l != "'# Metadata:\n'"]
+        _lines = [l for l in f if l != "# Metadata:\n"]
     with open(_fname, "w") as f:
         f.writelines(_lines)
     _metadata = AsciiIo.read_metadata_from_file(_fname)

--- a/tests/data_io/implementations/test_fabio_io.py
+++ b/tests/data_io/implementations/test_fabio_io.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -15,53 +15,60 @@
 # You should have received a copy of the GNU General Public License
 # along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for pydidas modules."""
+"""Unit tests for pydidas.data_io.implementations.fabio_io module."""
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
 
 
-import shutil
-import tempfile
-import unittest
-from pathlib import Path
-
 import fabio
 import numpy as np
+import pytest
+
+from tests.data_io.implementations.test_io_base import IoBaseTests
 
 from pydidas.core import FileReadError
 from pydidas.data_io.implementations.fabio_io import FabioIo
 
 
-class TestFabioIo(unittest.TestCase):
-    def setUp(self):
-        self._path = Path(tempfile.mkdtemp())
-        self._fname = self._path.joinpath("test.edf")
-        self._img_shape = (10, 10)
-        self._data = np.random.random(self._img_shape)
-        _file = fabio.edfimage.EdfImage(self._data)
-        _file.write(self._fname)
+@pytest.fixture
+def io_class():
+    return FabioIo
 
-    def tearDown(self):
-        shutil.rmtree(self._path)
 
-    def test_import_from_file(self):
-        data = FabioIo.import_from_file(self._fname)
-        self.assertTrue(np.allclose(data, self._data))
+@pytest.fixture
+def edf_file(tmp_path):
+    _fname = tmp_path / "test.edf"
+    _data = np.random.random((10, 10))
+    fabio.edfimage.EdfImage(_data).write(_fname)
+    return _fname, _data
 
-    def test_read_image__wrong_name(self):
-        with self.assertRaises(FileReadError):
-            FabioIo.import_from_file(self._fname.joinpath("dummy"))
 
-    def test_read_imag__wrong_type(self):
-        with open(self._fname, "w") as f:
-            f.write("now it's just an ASCII text file.")
-        with self.assertRaises(FileReadError):
-            FabioIo.import_from_file(self._fname)
+class TestFabioIo(IoBaseTests):
+    """Runs the generic IoBase tests against FabioIo."""
+
+
+def test_import_from_file(edf_file):
+    _fname, _data = edf_file
+    _result = FabioIo.import_from_file(_fname)
+    assert np.allclose(_result, _data)
+
+
+def test_import_from_file__wrong_name(edf_file):
+    _fname, _ = edf_file
+    with pytest.raises(FileReadError):
+        FabioIo.import_from_file(_fname / "dummy")
+
+
+def test_import_from_file__wrong_type(edf_file):
+    _fname, _ = edf_file
+    _fname.write_text("now it's just an ASCII text file.")
+    with pytest.raises(FileReadError):
+        FabioIo.import_from_file(_fname)
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main([__file__])

--- a/tests/data_io/implementations/test_hdf5_io.py
+++ b/tests/data_io/implementations/test_hdf5_io.py
@@ -28,10 +28,21 @@ import h5py
 import numpy as np
 import pytest
 
+from tests.data_io.implementations.test_io_base import IoBaseTests
+
 from pydidas.core import Dataset, FileReadError, UserConfigError
 from pydidas.core.constants import HDF5_EXTENSIONS
 from pydidas.core.utils.hdf5 import nxs_write_nxdata
 from pydidas.data_io.implementations.hdf5_io import Hdf5Io
+
+
+@pytest.fixture
+def io_class():
+    return Hdf5Io
+
+
+class TestHdf5Io(IoBaseTests):
+    """Runs the generic IoBase tests against Hdf5Io."""
 
 
 @pytest.fixture()
@@ -100,6 +111,15 @@ def test_import_from_file__w_metadata(config):
         assert np.allclose(_data.axis_ranges[_ax], _ref_data.axis_ranges[_ax])
     assert _data.data_label == config["data"].data_label
     assert _data.data_unit == config["data"].data_unit
+
+
+def test_import_from_file__w_metadata_requested_no_nxdata(config):
+    _fname = config["fname"]
+    with h5py.File(_fname, "r+") as _file:
+        _file["entry/data"].attrs["NX_class"] = ""
+    _data = Hdf5Io.import_from_file(config["fname"])
+    _ref_data = config["data"][config["data_slice"]]
+    assert np.allclose(_data, _ref_data)
 
 
 def test_import_from_file__w_metadata__from_axis_1(config):
@@ -286,9 +306,6 @@ def test_import_from_file__w_legacy_data(config, dataset):
                 f"entry/data/axis_{_i}",
                 f"entry/data/axis_{_i}_repr",
             )
-            # _file["entry/data"].attrs["axes"] = [
-            #     f"axis_{_i}_repr" for _i in range(_ref.ndim)
-            # ]
             _file["entry/data/"].create_group(f"axis_{_i}")
             _file[f"entry/data/axis_{_i}"].create_dataset(
                 "range", data=_ref.axis_ranges[_i]
@@ -329,6 +346,14 @@ def test_export_to_file__wrong_structure(config):
 def test_export_to_file__file_exists(config):
     with pytest.raises(FileExistsError):
         Hdf5Io.export_to_file(config["fname"], config["data"])
+
+
+def test_export_to_file__ndarray(config):
+    data = np.random.random((12, 13, 14))
+    Hdf5Io.export_to_file(config["fname"], data, overwrite=True)
+    with h5py.File(config["fname"], "r") as _file:
+        _written_data = _file["entry/data/data"][()]
+    assert np.allclose(_written_data, data)
 
 
 def test_export_to_file_file_exists_and_overwrite(config):

--- a/tests/data_io/implementations/test_io_base.py
+++ b/tests/data_io/implementations/test_io_base.py
@@ -14,8 +14,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
+#
+# Parts of this file have been created using AI tools.
 
-"""Unit tests for pydidas modules."""
+"""Unit tests for pydidas.data_io.implementations.io_base module."""
 
 __author__ = "Malte Storm"
 __copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
@@ -24,123 +26,134 @@ __maintainer__ = "Malte Storm"
 __status__ = "Production"
 
 
-import tempfile
-import unittest
-from pathlib import Path
-
 import numpy as np
+import pytest
 
-from pydidas.data_io import IoManager
+from pydidas.core import FileReadError
 from pydidas.data_io.implementations import IoBase
 
 
-def create_tester_class():
-    class Tester(IoBase):
-        format_name = "Tester"
-
-        @classmethod
-        def export_to_file(cls, filename, data, **kwargs):
-            cls._exported = [filename, data, kwargs]
-
-        @classmethod
-        def import_from_file(cls, filename, **kwargs):
-            cls._imported = [filename, kwargs]
+@pytest.fixture
+def io_class():
+    return IoBase
 
 
-class TestIoBase(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls._stored_exts_import = IoManager.registry_import.copy()
-        cls._stored_exts_export = IoManager.registry_export.copy()
-        create_tester_class()
-        cls._tmpdir = Path(tempfile.mkdtemp())
+class IoBaseTests:
+    """
+    Generic test class for shared IoBase functionality.
 
-    @classmethod
-    def tearDownClass(cls):
-        IoManager.registry_import = cls._stored_exts_import
-        IoManager.registry_export = cls._stored_exts_export
+    Concrete IoBase subclass test suites can inherit from this class to run
+    all generic tests against their implementation. Redefine the module-level
+    ``io_class`` fixture in the subclass test module to provide the class
+    under test.
+    """
 
-    def setUp(self): ...
+    def test_return_data__no_data(self, io_class):
+        with pytest.raises(ValueError):
+            io_class.return_data(None)
 
-    def tearDown(self): ...
+    def test_return_data__plain(self, io_class):
+        _input = np.random.random((10, 10))
+        _data = io_class.return_data(_input)
+        assert (_input == _data).all()
 
-    def test_export_to_file(self):
-        with self.assertRaises(NotImplementedError):
-            IoBase.export_to_file("", None)
-
-    def test_import_from_file(self):
-        with self.assertRaises(NotImplementedError):
-            IoBase.export_to_file("", None)
-
-    def test_check_for_existing_file__file_exists(self):
-        _fname = self._tmpdir / "test.txt"
-        with _fname.open("w") as f:
-            f.write("Test text")
-        with self.assertRaises(FileExistsError):
-            IoBase.check_for_existing_file(_fname)
-
-    def test_check_for_existing_file__file_exists_overwrite(self):
-        _fname = self._tmpdir / "test.txt"
-        with _fname.open("w") as f:
-            f.write("Test text")
-        IoBase.check_for_existing_file(_fname, overwrite=True)
-        # assert does not raise an error
-
-    def test_check_for_existing_file__file_does_not_exist(self):
-        _fname = self._tmpdir / "test.txt"
-        IoBase.check_for_existing_file(_fname)
-        # assert does not raise an error
-
-    def test_return_data__no_data(self):
-        with self.assertRaises(ValueError):
-            IoBase.return_data()
-
-    def test_return_data__plain(self):
-        IoBase._data = np.random.random((10, 10))
-        _data = IoBase.return_data()
-        self.assertTrue((IoBase._data == _data).all())
-
-    def test_return_data_w_roi(self):
+    def test_return_data__with_roi(self, io_class):
         _roi = [2, 8, 2, 8]
-        IoBase._data = np.random.random((10, 10))
-        _cropped_data = IoBase._data[_roi[0] : _roi[1], _roi[2] : _roi[3]]
-        _data = IoBase.return_data(roi=_roi)
-        self.assertTrue((_cropped_data == _data).all())
+        _input = np.random.random((10, 10))
+        _expected = _input[2:8, 2:8].copy()
+        _data = io_class.return_data(_input, roi=_roi)
+        assert (_expected == _data).all()
 
-    def test_return_data_w_return_type(self):
-        IoBase._data = np.random.random((10, 10))
-        _data = IoBase.return_data(datatype=np.float32)
-        self.assertEqual(_data.dtype, np.float32)
+    def test_return_data__with_return_type(self, io_class):
+        _input = np.random.random((10, 10))
+        _data = io_class.return_data(_input, astype=np.float32)
+        assert _data.dtype == np.float32
 
-    def test_return_data_w_binning(self):
-        IoBase._data = np.random.random((10, 10))
-        _data = IoBase.return_data(binning=2)
-        self.assertEqual(_data.shape, (5, 5))
+    def test_return_data__with_binning(self, io_class):
+        _input = np.random.random((10, 10))
+        _data = io_class.return_data(_input, binning=2)
+        assert _data.shape == (5, 5)
 
-    def test_get_data_range__simple(self):
+    def test_get_data_range__no_bounds(self, io_class):
         _data = np.random.random((15, 15))
-        _range = IoBase.get_data_range(_data)
-        self.assertEqual(_range[0], np.amin(_data))
-        self.assertEqual(_range[1], np.amax(_data))
+        _range = io_class.get_data_range(_data)
+        assert _range[0] == np.amin(_data)
+        assert _range[1] == np.amax(_data)
 
-    def test_get_data_range__lower_bound_only(self):
+    @pytest.mark.parametrize(
+        "data_range,expected_min,expected_max",
+        [
+            ((0.4, None), 0.4, None),
+            ((None, 0.8), None, 0.8),
+            ((0.3, 0.8), 0.3, 0.8),
+        ],
+    )
+    def test_get_data_range__with_bounds(
+        self, io_class, data_range, expected_min, expected_max
+    ):
         _data = np.random.random((15, 15))
-        _range = IoBase.get_data_range(_data, data_range=(0.4, None))
-        self.assertEqual(_range[0], 0.4)
-        self.assertEqual(_range[1], np.amax(_data))
+        _range = io_class.get_data_range(_data, data_range=data_range)
+        assert _range[0] == (
+            expected_min if expected_min is not None else np.amin(_data)
+        )
+        assert _range[1] == (
+            expected_max if expected_max is not None else np.amax(_data)
+        )
 
-    def test_get_data_range__upper_bound_only(self):
-        _data = np.random.random((15, 15))
-        _range = IoBase.get_data_range(_data, data_range=(None, 0.8))
-        self.assertEqual(_range[0], np.amin(_data))
-        self.assertEqual(_range[1], 0.8)
 
-    def test_get_data_range__both_bounds(self):
-        _data = np.random.random((15, 15))
-        _range = IoBase.get_data_range(_data, data_range=(0.3, 0.8))
-        self.assertEqual(_range[0], 0.3)
-        self.assertEqual(_range[1], 0.8)
+class TestIoBase(IoBaseTests):
+    """Runs the generic IoBase tests against IoBase itself."""
+
+
+# ------------------------------------------------------------------
+# IoBase-specific tests (abstract interface)
+# ------------------------------------------------------------------
+
+
+def test_export_to_file__raises_not_implemented():
+    with pytest.raises(NotImplementedError):
+        IoBase.export_to_file("", None)
+
+
+def test_import_from_file__raises_not_implemented():
+    with pytest.raises(NotImplementedError):
+        IoBase.import_from_file("")
+
+
+# ------------------------------------------------------------------
+# raise_filereaderror_from_exception
+# ------------------------------------------------------------------
+
+
+def test_raise_filereaderror_from_exception__raises_file_read_error():
+    _ex = RuntimeError("Something went wrong")
+    with pytest.raises(FileReadError):
+        IoBase.raise_filereaderror_from_exception(_ex, "file.txt")
+
+
+def test_raise_filereaderror_from_exception__short_filename_not_truncated():
+    _ex = RuntimeError("Some error")
+    _fname = "short_file.txt"
+    with pytest.raises(FileReadError) as exc_info:
+        IoBase.raise_filereaderror_from_exception(_ex, _fname)
+    assert _fname in str(exc_info.value)
+    assert "[...]" not in str(exc_info.value)
+
+
+def test_raise_filereaderror_from_exception__long_filename_truncated():
+    _ex = RuntimeError("Some error")
+    _fname = "a" * 70 + ".txt"
+    with pytest.raises(FileReadError) as exc_info:
+        IoBase.raise_filereaderror_from_exception(_ex, _fname)
+    assert "[...]" in str(exc_info.value)
+
+
+def test_raise_filereaderror_from_exception__numeric_first_arg_uses_second():
+    _ex = RuntimeError(42, "Descriptive error message")
+    with pytest.raises(FileReadError) as exc_info:
+        IoBase.raise_filereaderror_from_exception(_ex, "file.txt")
+    assert "Descriptive error message" in str(exc_info.value)
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main([__file__])

--- a/tests/data_io/implementations/test_io_exporter_matplotlib.py
+++ b/tests/data_io/implementations/test_io_exporter_matplotlib.py
@@ -1,0 +1,184 @@
+# This file is part of pydidas.
+#
+# Copyright 2026, Helmholtz-Zentrum Hereon
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# pydidas is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# Pydidas is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
+#
+# Parts of this file have been created using AI tools.
+
+"""Unit tests for pydidas.data_io.implementations.io_exporter_matplotlib module."""
+
+__author__ = "Malte Storm"
+__copyright__ = "Copyright 2026, Helmholtz-Zentrum Hereon"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Malte Storm"
+__status__ = "Production"
+
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from tests.data_io.implementations.test_io_base import IoBaseTests
+
+from pydidas.core import Dataset
+from pydidas.data_io.implementations.io_exporter_matplotlib import IoExporterMatplotlib
+
+
+@pytest.fixture
+def io_class():
+    return IoExporterMatplotlib
+
+
+@pytest.fixture
+def data_2d():
+    return np.random.default_rng(0).random((20, 25))
+
+
+@pytest.fixture
+def data_1d():
+    return np.random.default_rng(1).random(50)
+
+
+class TestIoExporterMatplotlib(IoBaseTests):
+    """Runs the generic IoBase tests against IoExporterMatplotlib."""
+
+
+def test_class_dimensions():
+    assert IoExporterMatplotlib.dimensions == [1, 2]
+
+
+def test_class_extensions_export_empty():
+    assert IoExporterMatplotlib.extensions_export == []
+
+
+def test_class_extensions_import_empty():
+    assert IoExporterMatplotlib.extensions_import == []
+
+
+def test_export_to_file__dispatches_1d_to_plot(tmp_path, data_1d):
+    with (
+        patch.object(IoExporterMatplotlib, "export_matplotlib_plot") as mock_plot,
+        patch.object(IoExporterMatplotlib, "export_matplotlib_figure") as mock_fig,
+    ):
+        IoExporterMatplotlib.export_to_file(tmp_path / "test.png", data_1d)
+    mock_plot.assert_called_once()
+    mock_fig.assert_not_called()
+
+
+def test_export_to_file__dispatches_2d_to_figure(tmp_path, data_2d):
+    with (
+        patch.object(IoExporterMatplotlib, "export_matplotlib_plot") as mock_plot,
+        patch.object(IoExporterMatplotlib, "export_matplotlib_figure") as mock_fig,
+    ):
+        IoExporterMatplotlib.export_to_file(tmp_path / "test.png", data_2d)
+    mock_fig.assert_called_once()
+    mock_plot.assert_not_called()
+
+
+def test_export_matplotlib_figure__creates_file(tmp_path, data_2d):
+    _fname = tmp_path / "fig.png"
+    IoExporterMatplotlib.export_matplotlib_figure(_fname, data_2d)
+    assert _fname.exists()
+
+
+def test_export_matplotlib_figure__raises_if_file_exists(tmp_path, data_2d):
+    _fname = tmp_path / "fig.png"
+    IoExporterMatplotlib.export_matplotlib_figure(_fname, data_2d)
+    with pytest.raises(FileExistsError):
+        IoExporterMatplotlib.export_matplotlib_figure(_fname, data_2d)
+
+
+def test_export_matplotlib_figure__overwrite(tmp_path, data_2d):
+    _fname = tmp_path / "fig.png"
+    IoExporterMatplotlib.export_matplotlib_figure(_fname, data_2d)
+    IoExporterMatplotlib.export_matplotlib_figure(_fname, data_2d, overwrite=True)
+    assert _fname.exists()
+
+
+def test_export_matplotlib_figure__w_plain_ndarray(tmp_path):
+    _fname = tmp_path / "fig_array.png"
+    IoExporterMatplotlib.export_matplotlib_figure(
+        _fname, np.random.default_rng(2).random((15, 20))
+    )
+    assert _fname.exists()
+
+
+def test_export_matplotlib_figure__w_dataset(tmp_path):
+    _fname = tmp_path / "fig_ds.png"
+    IoExporterMatplotlib.export_matplotlib_figure(
+        _fname, Dataset(np.random.default_rng(3).random((15, 20)))
+    )
+    assert _fname.exists()
+
+
+def test_export_matplotlib_figure__w_colormap(tmp_path, data_2d):
+    _fname = tmp_path / "fig_cmap.png"
+    IoExporterMatplotlib.export_matplotlib_figure(_fname, data_2d, colormap="viridis")
+    assert _fname.exists()
+
+
+def test_export_matplotlib_figure__w_data_range(tmp_path, data_2d):
+    _fname = tmp_path / "fig_range.png"
+    IoExporterMatplotlib.export_matplotlib_figure(
+        _fname, data_2d, data_range=(0.2, 0.8)
+    )
+    assert _fname.exists()
+
+
+def test_export_matplotlib_plot__creates_file(tmp_path, data_1d):
+    _fname = tmp_path / "plot.png"
+    IoExporterMatplotlib.export_matplotlib_plot(_fname, data_1d)
+    assert _fname.exists()
+
+
+def test_export_matplotlib_plot__raises_if_file_exists(tmp_path, data_1d):
+    _fname = tmp_path / "plot.png"
+    IoExporterMatplotlib.export_matplotlib_plot(_fname, data_1d)
+    with pytest.raises(FileExistsError):
+        IoExporterMatplotlib.export_matplotlib_plot(_fname, data_1d)
+
+
+def test_export_matplotlib_plot__overwrite(tmp_path, data_1d):
+    _fname = tmp_path / "plot.png"
+    IoExporterMatplotlib.export_matplotlib_plot(_fname, data_1d)
+    IoExporterMatplotlib.export_matplotlib_plot(_fname, data_1d, overwrite=True)
+    assert _fname.exists()
+
+
+def test_export_matplotlib_plot__w_plain_ndarray(tmp_path):
+    _fname = tmp_path / "plot_array.png"
+    IoExporterMatplotlib.export_matplotlib_plot(
+        _fname, np.random.default_rng(4).random(50)
+    )
+    assert _fname.exists()
+
+
+def test_export_matplotlib_plot__w_dataset(tmp_path):
+    _data = Dataset(np.random.default_rng(5).random(50))
+    _data.update_axis_range(0, np.linspace(0, 10, 50))
+    _fname = tmp_path / "plot_ds.png"
+    IoExporterMatplotlib.export_matplotlib_plot(_fname, _data)
+    assert _fname.exists()
+
+
+def test_export_matplotlib_plot__w_data_range(tmp_path, data_1d):
+    _fname = tmp_path / "plot_range.png"
+    IoExporterMatplotlib.export_matplotlib_plot(_fname, data_1d, data_range=(0.2, 0.8))
+    assert _fname.exists()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/data_io/implementations/test_jpeg_io.py
+++ b/tests/data_io/implementations/test_jpeg_io.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for pydidas modules."""
+"""Unit tests for pydidas.data_io.implementations.jpeg_io module."""
 
 __author__ = "Malte Storm"
 __copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
@@ -24,61 +24,57 @@ __maintainer__ = "Malte Storm"
 __status__ = "Production"
 
 
-import shutil
-import tempfile
-import unittest
-from pathlib import Path
-
 import numpy as np
+import pytest
+
+from tests.data_io.implementations.test_io_base import IoBaseTests
 
 from pydidas.core.constants import JPG_EXTENSIONS
 from pydidas.data_io.implementations.jpeg_io import JpegIo
 
 
-class TestJpegIo(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls._path = Path(tempfile.mkdtemp())
-        cls._fname = cls._path / "test.jpg"
-        cls._data_shape = (127, 137)
-        cls._data = np.random.random(cls._data_shape)
-        cls._index = 0
+@pytest.fixture
+def io_class():
+    return JpegIo
 
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls._path)
 
-    @classmethod
-    def get_fname(cls):
-        cls._index += 1
-        return f"test_name{cls._index:03d}.jpg"
+@pytest.fixture
+def jpeg_data(tmp_path):
+    _data = np.random.random((127, 137))
+    _fname = tmp_path / "test.jpg"
+    return _fname, _data
 
-    def setUp(self):
-        self._target_roi = (slice(0, 5, None), slice(0, 5, None))
 
-    def tearDown(self): ...
+class TestJpegIo(IoBaseTests):
+    """Runs the generic IoBase tests against JpegIo."""
 
-    def test_class_extensions(self):
-        for _ext in JPG_EXTENSIONS:
-            self.assertIn(_ext, JpegIo.extensions_export)
 
-    def test_export_to_file__file_exists(self):
-        JpegIo.export_to_file(self._fname, self._data)
-        with self.assertRaises(FileExistsError):
-            JpegIo.export_to_file(self._fname, self._data)
+def test_class_extensions():
+    for _ext in JPG_EXTENSIONS:
+        assert _ext in JpegIo.extensions_export
 
-    def test_export_to_file__file_exists_and_overwrite(self):
-        _fname = self._path / self.get_fname()
-        JpegIo.export_to_file(_fname, self._data)
-        _size = _fname.stat().st_size
-        JpegIo.export_to_file(_fname, self._data[:57], overwrite=True)
-        _size_new = _fname.stat().st_size
-        self.assertNotEqual(_size, _size_new)
 
-    def test_export_to_file(self):
-        _fname = self._path / self.get_fname()
-        JpegIo.export_to_file(_fname, self._data)
+def test_export_to_file__file_exists(jpeg_data):
+    _fname, _data = jpeg_data
+    JpegIo.export_to_file(_fname, _data)
+    with pytest.raises(FileExistsError):
+        JpegIo.export_to_file(_fname, _data)
+
+
+def test_export_to_file__file_exists_and_overwrite(tmp_path):
+    _fname = tmp_path / "test_overwrite.jpg"
+    _data = np.random.random((127, 137))
+    JpegIo.export_to_file(_fname, _data)
+    _size = _fname.stat().st_size
+    JpegIo.export_to_file(_fname, _data[:57], overwrite=True)
+    assert _fname.stat().st_size != _size
+
+
+def test_export_to_file(jpeg_data):
+    _fname, _data = jpeg_data
+    JpegIo.export_to_file(_fname, _data)
+    assert _fname.exists()
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main([__file__])

--- a/tests/data_io/implementations/test_numpy_io.py
+++ b/tests/data_io/implementations/test_numpy_io.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2024, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -15,82 +15,86 @@
 # You should have received a copy of the GNU General Public License
 # along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for pydidas modules."""
+"""Unit tests for pydidas.data_io.implementations.numpy_io module."""
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2024, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
 
 
-import shutil
-import tempfile
-import unittest
-from pathlib import Path
-
 import numpy as np
+import pytest
+
+from tests.data_io.implementations.test_io_base import IoBaseTests
 
 from pydidas.core import FileReadError
 from pydidas.core.constants import NUMPY_EXTENSIONS
 from pydidas.data_io.implementations.numpy_io import NumpyIo
 
 
-class TestNumpyIo(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls._path = Path(tempfile.mkdtemp())
-        cls._fname = cls._path.joinpath("test.npy")
-        cls._data_shape = (12, 13, 14, 15)
-        cls._data = np.random.random(cls._data_shape)
-        np.save(cls._fname, cls._data)
+@pytest.fixture
+def io_class():
+    return NumpyIo
 
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls._path)
 
-    def setUp(self):
-        self._target_roi = (slice(0, 5, None), slice(0, 5, None))
+@pytest.fixture
+def npy_file(tmp_path):
+    _data = np.random.random((12, 13, 14, 15))
+    _fname = tmp_path / "test.npy"
+    np.save(_fname, _data)
+    return _fname, _data
 
-    def tearDown(self): ...
 
-    def test_class_extensions(self):
-        for _ext in NUMPY_EXTENSIONS:
-            self.assertIn(_ext, NumpyIo.extensions_export)
-            self.assertIn(_ext, NumpyIo.extensions_import)
+class TestNumpyIo(IoBaseTests):
+    """Runs the generic IoBase tests against NumpyIo."""
 
-    def test_import_from_file__default(self):
-        _data = NumpyIo.import_from_file(self._fname)
-        self.assertTrue(np.allclose(_data, self._data))
 
-    def test_import_from_file__wrong_name(self):
-        with self.assertRaises(FileReadError):
-            NumpyIo.import_from_file(self._fname.joinpath("dummy"), datatype=np.float64)
+def test_class_extensions():
+    for _ext in NUMPY_EXTENSIONS:
+        assert _ext in NumpyIo.extensions_export
+        assert _ext in NumpyIo.extensions_import
 
-    def test_import_from_file__wrong_type(self):
-        _fname_new = self._path.joinpath("test2.dat")
-        with open(_fname_new, "w") as f:
-            f.write("now it's just an ASCII text file.")
-        with self.assertRaises(FileReadError):
-            NumpyIo.import_from_file(_fname_new, datatype=np.float64)
 
-    def test_export_to_file__file_exists(self):
-        with self.assertRaises(FileExistsError):
-            NumpyIo.export_to_file(self._fname, self._data)
+def test_import_from_file__default(npy_file):
+    _fname, _data = npy_file
+    assert np.allclose(NumpyIo.import_from_file(_fname), _data)
 
-    def test_export_to_file__file_exists_and_overwrite(self):
-        _fname = self._path.joinpath("test_new.npy")
-        NumpyIo.export_to_file(_fname, self._data)
-        NumpyIo.export_to_file(_fname, self._data[:11], overwrite=True)
-        _data = NumpyIo.import_from_file(_fname)
-        self.assertEqual(_data.shape, (11,) + self._data_shape[1:])
 
-    def test_export_to_file__simple(self):
-        _fname = self._path.joinpath("test_fname.npy")
-        NumpyIo.export_to_file(_fname, self._data)
-        _data = NumpyIo.import_from_file(_fname)
-        self.assertTrue(np.allclose(_data, self._data))
+def test_import_from_file__wrong_name(npy_file):
+    _fname, _ = npy_file
+    with pytest.raises(FileReadError):
+        NumpyIo.import_from_file(_fname / "dummy", astype=np.float64)
+
+
+def test_import_from_file__wrong_type(tmp_path):
+    _fname = tmp_path / "test2.dat"
+    _fname.write_text("now it's just an ASCII text file.")
+    with pytest.raises(FileReadError):
+        NumpyIo.import_from_file(_fname, astype=np.float64)
+
+
+def test_export_to_file__file_exists(npy_file):
+    _fname, _data = npy_file
+    with pytest.raises(FileExistsError):
+        NumpyIo.export_to_file(_fname, _data)
+
+
+def test_export_to_file__file_exists_and_overwrite(tmp_path):
+    _data = np.random.random((12, 13, 14, 15))
+    _fname = tmp_path / "test_new.npy"
+    NumpyIo.export_to_file(_fname, _data)
+    NumpyIo.export_to_file(_fname, _data[:11], overwrite=True)
+    assert NumpyIo.import_from_file(_fname).shape == (11,) + _data.shape[1:]
+
+
+def test_export_to_file__simple(tmp_path):
+    _data = np.random.random((12, 13, 14, 15))
+    _fname = tmp_path / "test_fname.npy"
+    NumpyIo.export_to_file(_fname, _data)
+    assert np.allclose(NumpyIo.import_from_file(_fname), _data)
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main([__file__])

--- a/tests/data_io/implementations/test_raw_io.py
+++ b/tests/data_io/implementations/test_raw_io.py
@@ -102,7 +102,7 @@ def test_export_to_file__file_exists_and_overwrite(tmp_path, raw_file):
     _fname = tmp_path / "test_overwrite.bin"
     RawIo.export_to_file(_fname, _data[:11])
     RawIo.export_to_file(_fname, _data, overwrite=True)
-    assert RawIo.import_from_file(_fname_orig, **_READ_KWS).shape == _DATA_SHAPE
+    assert RawIo.import_from_file(_fname, **_READ_KWS).shape == _DATA_SHAPE
 
 
 def test_export_to_file__simple(tmp_path):

--- a/tests/data_io/implementations/test_raw_io.py
+++ b/tests/data_io/implementations/test_raw_io.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for pydidas modules."""
+"""Unit tests for pydidas.data_io.implementations.raw_io module."""
 
 __author__ = "Malte Storm"
 __copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
@@ -24,80 +24,93 @@ __maintainer__ = "Malte Storm"
 __status__ = "Production"
 
 
-import shutil
-import tempfile
-import unittest
-from pathlib import Path
-
 import numpy as np
+import pytest
 
-from pydidas.core import FileReadError
+from tests.data_io.implementations.test_io_base import IoBaseTests
+
+from pydidas.core import FileReadError, UserConfigError
 from pydidas.core.constants import BINARY_EXTENSIONS
 from pydidas.data_io.implementations.raw_io import RawIo
 
 
-class TestRawIo(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls._path = Path(tempfile.mkdtemp())
-        cls._fname = cls._path.joinpath("test.dat")
-        cls._data_shape = (12, 13, 14)
-        cls._data = np.random.random(cls._data_shape)
-        cls._index = 0
-        cls._read_kws = {"datatype": np.float64, "shape": cls._data_shape}
-        cls._data.tofile(cls._fname)
+_DATA_SHAPE = (12, 13, 14)
+_READ_KWS = {"datatype": np.float64, "shape": _DATA_SHAPE}
 
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls._path)
 
-    @classmethod
-    def get_fname(cls):
-        cls._index += 1
-        return f"test_name{cls._index:03d}.bin"
+@pytest.fixture
+def io_class():
+    return RawIo
 
-    def setUp(self):
-        self._target_roi = (slice(0, 5, None), slice(0, 5, None))
 
-    def tearDown(self): ...
+@pytest.fixture
+def raw_file(tmp_path):
+    _data = np.random.random(_DATA_SHAPE)
+    _fname = tmp_path / "test.dat"
+    _data.tofile(_fname)
+    return _fname, _data
 
-    def test_class_extensions(self):
-        for _ext in BINARY_EXTENSIONS:
-            self.assertIn(_ext, RawIo.extensions_export)
-            self.assertIn(_ext, RawIo.extensions_import)
 
-    def test_import_from_file__default(self):
-        _data = RawIo.import_from_file(self._fname, **self._read_kws)
-        self.assertTrue(np.allclose(_data, self._data))
+class TestRawIo(IoBaseTests):
+    """Runs the generic IoBase tests against RawIo."""
 
-    def test_import_from_file__wrong_name(self):
-        with self.assertRaises(FileReadError):
-            RawIo.import_from_file(self._fname.joinpath("dummy"), datatype=np.float64)
 
-    def test_import_from_file__wrong_type(self):
-        _fname_new = self._path.joinpath("test2.dat")
-        with open(_fname_new, "w") as f:
-            f.write("now it's just an ASCII text file.")
-        with self.assertRaises(FileReadError):
-            RawIo.import_from_file(_fname_new, datatype=np.float64)
+def test_class_extensions():
+    for _ext in BINARY_EXTENSIONS:
+        assert _ext in RawIo.extensions_export
+        assert _ext in RawIo.extensions_import
 
-    def test_export_to_file__file_exists(self):
-        with self.assertRaises(FileExistsError):
-            RawIo.export_to_file(self._fname, self._data)
 
-    def test_export_to_file__file_exists_and_overwrite(self):
-        _fname = self._path.joinpath(self.get_fname())
-        RawIo.export_to_file(_fname, self._data[:11])
-        RawIo.export_to_file(_fname, self._data, overwrite=True)
-        _data = RawIo.import_from_file(self._fname, **self._read_kws)
-        self.assertEqual(_data.shape, self._data_shape)
+def test_import_from_file__default(raw_file):
+    _fname, _data = raw_file
+    assert np.allclose(RawIo.import_from_file(_fname, **_READ_KWS), _data)
 
-    def test_export_to_file__simple(self):
-        _fname = self._path.joinpath(self.get_fname())
-        RawIo.export_to_file(_fname, self._data)
-        _data = RawIo.import_from_file(_fname, **self._read_kws)
-        self.assertTrue(np.allclose(_data, self._data))
+
+def test_import_from_file__shape_missing(raw_file):
+    _fname, _data = raw_file
+    with pytest.raises(UserConfigError, match="The shape must be specified"):
+        RawIo.import_from_file(_fname, datatype=np.float16)
+
+
+def test_import_from_file__datatype_missing(raw_file):
+    _fname, _data = raw_file
+    with pytest.raises(UserConfigError, match="The datatype must be specified"):
+        RawIo.import_from_file(_fname, shape=_DATA_SHAPE)
+
+
+def test_import_from_file__wrong_name(raw_file):
+    _fname, _ = raw_file
+    with pytest.raises(FileReadError):
+        RawIo.import_from_file(_fname / "dummy", datatype=np.float64, shape=_DATA_SHAPE)
+
+
+def test_import_from_file__wrong_type(tmp_path):
+    _fname = tmp_path / "test2.dat"
+    _fname.write_text("now it's just an ASCII text file.")
+    with pytest.raises(FileReadError):
+        RawIo.import_from_file(_fname, datatype=np.float64, shape=_DATA_SHAPE)
+
+
+def test_export_to_file__file_exists(raw_file):
+    _fname, _data = raw_file
+    with pytest.raises(FileExistsError):
+        RawIo.export_to_file(_fname, _data)
+
+
+def test_export_to_file__file_exists_and_overwrite(tmp_path, raw_file):
+    _fname_orig, _data = raw_file
+    _fname = tmp_path / "test_overwrite.bin"
+    RawIo.export_to_file(_fname, _data[:11])
+    RawIo.export_to_file(_fname, _data, overwrite=True)
+    assert RawIo.import_from_file(_fname_orig, **_READ_KWS).shape == _DATA_SHAPE
+
+
+def test_export_to_file__simple(tmp_path):
+    _data = np.random.random(_DATA_SHAPE)
+    _fname = tmp_path / "test_simple.bin"
+    RawIo.export_to_file(_fname, _data)
+    assert np.allclose(RawIo.import_from_file(_fname, **_READ_KWS), _data)
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main([__file__])

--- a/tests/data_io/implementations/test_tiff_io.py
+++ b/tests/data_io/implementations/test_tiff_io.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2024, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -15,168 +15,144 @@
 # You should have received a copy of the GNU General Public License
 # along with Pydidas. If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for pydidas modules."""
+"""Unit tests for pydidas.data_io.implementations.tiff_io module."""
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2024, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
 
 
-import shutil
-import tempfile
-import unittest
+from collections.abc import Callable
+from itertools import count
 from pathlib import Path
 
 import numpy as np
-import skimage.io
+import pytest
+
+from tests.data_io.implementations.test_io_base import IoBaseTests
 
 from pydidas.core import FileReadError
 from pydidas.core.constants import TIFF_EXTENSIONS
+from pydidas.core.lazy_imports.skimage import imsave
 from pydidas.data_io.implementations.tiff_io import TiffIo
 
 
-class TestTiffIo(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls._path = Path(tempfile.mkdtemp())
-        cls._fname = cls._path.joinpath("test.tif")
-        cls._data_shape = (12, 13)
-        cls._data = np.random.random(cls._data_shape)
-        cls._index = 0
-        skimage.io.imsave(cls._fname, cls._data)
+@pytest.fixture
+def io_class():
+    return TiffIo
 
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls._path)
 
-    @classmethod
-    def get_fname(cls):
-        cls._index += 1
-        return f"test_name{cls._index:03d}.tif"
+@pytest.fixture
+def tiff_file(tmp_path: Path) -> tuple[Path, np.ndarray]:
+    data = np.random.random((12, 13))
+    filename = tmp_path / "test.tif"
+    imsave(filename, data)
+    return filename, data
 
-    def setUp(self):
-        self._target_roi = (slice(0, 5, None), slice(0, 5, None))
 
-    def tearDown(self): ...
+@pytest.fixture
+def tiff_filename_factory(tmp_path: Path) -> Callable[[], Path]:
+    index = count(1)
 
-    def test_class_extensions(self):
-        for _ext in TIFF_EXTENSIONS:
-            self.assertIn(_ext, TiffIo.extensions_export)
-            self.assertIn(_ext, TiffIo.extensions_import)
+    def factory() -> Path:
+        return tmp_path / f"test_name{next(index):03d}.tif"
 
-    def test_import_from_file__default(self):
-        _data = TiffIo.import_from_file(self._fname)
-        self.assertTrue(np.allclose(_data, self._data))
+    return factory
 
-    def test_import_from_file__wrong_name(self):
-        with self.assertRaises(FileReadError):
-            TiffIo.import_from_file(self._fname.joinpath("dummy"))
 
-    def test_import_from_file__wrong_type(self):
-        with open(self._fname, "w") as f:
-            f.write("now it's just an ASCII text file.")
-        with self.assertRaises(FileReadError):
-            TiffIo.import_from_file(self._fname)
+class TestTiffIo(IoBaseTests):
+    """Runs the generic IoBase tests against TiffIo."""
 
-    def test_export_to_file__file_exists(self):
-        with self.assertRaises(FileExistsError):
-            TiffIo.export_to_file(self._fname, self._data)
 
-    def test_export_to_file__file_exists_and_overwrite(self):
-        _fname = self._path.joinpath(self.get_fname())
-        TiffIo.export_to_file(_fname, self._data)
-        TiffIo.export_to_file(_fname, self._data[:11], overwrite=True)
-        _data = TiffIo.import_from_file(_fname)
-        self.assertEqual(_data.shape, (11,) + self._data_shape[1:])
+def test_class_extensions() -> None:
+    for extension in TIFF_EXTENSIONS:
+        assert extension in TiffIo.extensions_export
+        assert extension in TiffIo.extensions_import
 
-    def test_export_to_file__simple(self):
-        _fname = self._path.joinpath(self.get_fname())
-        TiffIo.export_to_file(_fname, self._data)
-        _data = TiffIo.import_from_file(_fname)
-        self.assertTrue(np.allclose(_data, self._data))
 
-    def test_export_to_file__8bit_int(self):
-        _fname = self._path.joinpath(self.get_fname())
-        _raw = (np.random.random((11, 12, 13)) * 125).astype(np.int8)
-        TiffIo.export_to_file(_fname, _raw)
-        _data = TiffIo.import_from_file(_fname)
-        self.assertTrue(np.allclose(_data, _raw))
-        self.assertEqual(_raw.dtype, _data.dtype)
+def test_import_from_file__default(tiff_file: tuple[Path, np.ndarray]) -> None:
+    filename, data = tiff_file
+    assert np.allclose(TiffIo.import_from_file(filename), data)
 
-    def test_export_to_file__8bit_uint(self):
-        _fname = self._path.joinpath(self.get_fname())
-        _raw = (np.random.random((11, 12, 13)) * 125).astype(np.uint8)
-        TiffIo.export_to_file(_fname, _raw)
-        _data = TiffIo.import_from_file(_fname)
-        self.assertTrue(np.allclose(_data, _raw))
-        self.assertEqual(_raw.dtype, _data.dtype)
 
-    def test_export_to_file__16bit_int(self):
-        _fname = self._path.joinpath(self.get_fname())
-        _raw = (np.random.random((11, 12, 13)) * 1257).astype(np.int16)
-        TiffIo.export_to_file(_fname, _raw)
-        _data = TiffIo.import_from_file(_fname)
-        self.assertTrue(np.allclose(_data, _raw))
-        self.assertEqual(_raw.dtype, _data.dtype)
+def test_import_from_file__wrong_name(
+    tiff_file: tuple[Path, np.ndarray],
+) -> None:
+    filename, _ = tiff_file
+    with pytest.raises(FileReadError):
+        TiffIo.import_from_file(filename / "dummy")
 
-    def test_export_to_file__16bit_uint(self):
-        _fname = self._path.joinpath(self.get_fname())
-        _raw = (np.random.random((11, 12, 13)) * 1257).astype(np.uint16)
-        TiffIo.export_to_file(_fname, _raw)
-        _data = TiffIo.import_from_file(_fname)
-        self.assertTrue(np.allclose(_data, _raw))
-        self.assertEqual(_raw.dtype, _data.dtype)
 
-    def test_export_to_file__32bit_int(self):
-        _fname = self._path.joinpath(self.get_fname())
-        _raw = (np.random.random((11, 12, 13)) * 12573).astype(np.int32)
-        TiffIo.export_to_file(_fname, _raw)
-        _data = TiffIo.import_from_file(_fname)
-        self.assertTrue(np.allclose(_data, _raw))
-        self.assertEqual(_raw.dtype, _data.dtype)
+def test_import_from_file__wrong_type(
+    tiff_file: tuple[Path, np.ndarray],
+) -> None:
+    filename, _ = tiff_file
+    filename.write_text("now it's just an ASCII text file.")
+    with pytest.raises(FileReadError):
+        TiffIo.import_from_file(filename)
 
-    def test_export_to_file__32bit_uint(self):
-        _fname = self._path.joinpath(self.get_fname())
-        _raw = (np.random.random((11, 12, 13)) * 12573).astype(np.uint32)
-        TiffIo.export_to_file(_fname, _raw)
-        _data = TiffIo.import_from_file(_fname)
-        self.assertTrue(np.allclose(_data, _raw))
-        self.assertEqual(_raw.dtype, _data.dtype)
 
-    def test_export_to_file__16bit_float(self):
-        _fname = self._path.joinpath(self.get_fname())
-        _raw = (np.random.random((11, 12, 13))).astype(np.float16)
-        TiffIo.export_to_file(_fname, _raw)
-        _data = TiffIo.import_from_file(_fname)
-        self.assertTrue(np.allclose(_data, _raw))
-        self.assertEqual(_raw.dtype, _data.dtype)
+def test_export_to_file__file_exists(
+    tiff_file: tuple[Path, np.ndarray],
+) -> None:
+    filename, data = tiff_file
+    with pytest.raises(FileExistsError):
+        TiffIo.export_to_file(filename, data)
 
-    def test_export_to_file__32bit_float(self):
-        _fname = self._path.joinpath(self.get_fname())
-        _raw = (np.random.random((11, 12, 13))).astype(np.float32)
-        TiffIo.export_to_file(_fname, _raw)
-        _data = TiffIo.import_from_file(_fname)
-        self.assertTrue(np.allclose(_data, _raw))
-        self.assertEqual(_raw.dtype, _data.dtype)
 
-    def test_export_to_file__64bit_float(self):
-        _fname = self._path.joinpath(self.get_fname())
-        _raw = (np.random.random((11, 12, 13))).astype(np.float64)
-        TiffIo.export_to_file(_fname, _raw)
-        _data = TiffIo.import_from_file(_fname)
-        self.assertTrue(np.allclose(_data, _raw))
-        self.assertEqual(_data.dtype, np.float32)
+def test_export_to_file__file_exists_and_overwrite(
+    tiff_file: tuple[Path, np.ndarray],
+    tiff_filename_factory: Callable[[], Path],
+) -> None:
+    filename = tiff_filename_factory()
+    _, data = tiff_file
+    TiffIo.export_to_file(filename, data)
+    TiffIo.export_to_file(filename, data[:11], overwrite=True)
+    imported = TiffIo.import_from_file(filename)
+    assert imported.shape == (11,) + data.shape[1:]
 
-    def test_export_to_file__1282bit_float(self):
-        _fname = self._path.joinpath(self.get_fname())
-        _raw = (np.random.random((11, 12, 13))).astype(np.longdouble)
-        TiffIo.export_to_file(_fname, _raw)
-        _data = TiffIo.import_from_file(_fname)
-        self.assertTrue(np.allclose(_data, _raw))
-        self.assertEqual(_data.dtype, np.float32)
+
+def test_export_to_file__simple(
+    tiff_file: tuple[Path, np.ndarray],
+    tiff_filename_factory: Callable[[], Path],
+) -> None:
+    filename = tiff_filename_factory()
+    _, data = tiff_file
+    TiffIo.export_to_file(filename, data)
+    imported = TiffIo.import_from_file(filename)
+    assert np.allclose(imported, data)
+
+
+@pytest.mark.parametrize(
+    "dtype,scale,expected_dtype",
+    [
+        (np.int8, 125, np.int8),
+        (np.uint8, 125, np.uint8),
+        (np.int16, 1257, np.int16),
+        (np.uint16, 1257, np.uint16),
+        (np.int32, 12573, np.int32),
+        (np.uint32, 12573, np.uint32),
+        (np.float16, 1, np.float16),
+        (np.float32, 1, np.float32),
+        (np.float64, 1, np.float32),
+        (np.longdouble, 1, np.float32),
+    ],
+)
+def test_export_to_file__dtype_roundtrip(
+    tiff_filename_factory: Callable[[], Path],
+    dtype: np.dtype,
+    scale: int,
+    expected_dtype: np.dtype,
+) -> None:
+    filename = tiff_filename_factory()
+    raw = (np.random.random((11, 12, 13)) * scale).astype(dtype)
+    TiffIo.export_to_file(filename, raw)
+    imported = TiffIo.import_from_file(filename)
+    assert np.allclose(imported, raw)
+    assert imported.dtype == expected_dtype
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main([__file__])


### PR DESCRIPTION
Reworked the way the data importers worked and moved all functionality to static methods.

Fixed an issue in ImageMathFrame which did not allow to import 64bit float images.