### PR TITLE
Fix segfault on wayland with Qt6

### DIFF
--- a/src/pydidas/gui/gui_excepthook_.py
+++ b/src/pydidas/gui/gui_excepthook_.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -21,7 +21,7 @@ Module with the pydidas excepthook for the GUI.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -70,7 +70,11 @@ def gui_excepthook(exc_type, exception, trace):
             "Configuration Error" if exc_type is UserConfigError else "File read error"
         )
         _app.sig_gui_exception_occurred.emit()
-        _ = PydidasExceptionMessageBox(text=_exc_repr, title=_title).exec_()
+        _box = PydidasExceptionMessageBox(text=_exc_repr, title=_title)
+        if hasattr(_box, "exec"):
+            _box.exec()
+        else:
+            _box.exec_()
         return
     with StringIO() as _tmpfile:
         traceback.print_tb(trace, None, _tmpfile)

--- a/src/pydidas/widgets/dialogues/acknowledge_box.py
+++ b/src/pydidas/widgets/dialogues/acknowledge_box.py
@@ -166,7 +166,7 @@ class AcknowledgeBox(QtWidgets.QDialog, CreateWidgetsMixIn):
         _scroll_width = max(
             50, min(120, self._widgets["label"].font_metric_width_factor)
         )
-        self._widgets["scroll_area"].setFixedWidth(_scroll_width * _font_width)
+        self._widgets["scroll_area"].setFixedWidth(int(_scroll_width * _font_width))
         self._widgets["scroll_area"].setFixedHeight(
             self.__qtapp.font_height * (_n_lines + 4)
         )

--- a/src/pydidas/widgets/workflow_edit/plugin_in_workflow_box.py
+++ b/src/pydidas/widgets/workflow_edit/plugin_in_workflow_box.py
@@ -1,6 +1,6 @@
 # This file is part of pydidas.
 #
-# Copyright 2023 - 2025, Helmholtz-Zentrum Hereon
+# Copyright 2023 - 2026, Helmholtz-Zentrum Hereon
 # SPDX-License-Identifier: GPL-3.0-only
 #
 # pydidas is free software: you can redistribute it and/or modify
@@ -22,7 +22,7 @@ to display plugin processing steps in the WorkflowTree.
 """
 
 __author__ = "Malte Storm"
-__copyright__ = "Copyright 2023 - 2025, Helmholtz-Zentrum Hereon"
+__copyright__ = "Copyright 2023 - 2026, Helmholtz-Zentrum Hereon"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Malte Storm"
 __status__ = "Production"
@@ -280,20 +280,28 @@ class PluginInWorkflowBox(CreateWidgetsMixIn, QFrame):
             self.flags["inconsistent"] = False
             self.__update_style()
 
-    def mouseMoveEvent(self, event: QtCore.QEvent):
+    def mouseMoveEvent(self, event: QtGui.QMouseEvent):
         """
         Implement a mouse move event to drag the plugins to a new position in the
         WorkflowTree.
         """
-        if event.buttons() == QtCore.Qt.LeftButton:
-            _drag = QtGui.QDrag(self)
-            _mime = QtCore.QMimeData()
-            _drag.setMimeData(_mime)
+        if not (event.buttons() & QtCore.Qt.LeftButton):
+            return super().mouseMoveEvent(event)
 
-            _pixmap = QtGui.QPixmap(self.size())
-            self.render(_pixmap)
-            _drag.setPixmap(_pixmap)
-            _drag.exec_(QtCore.Qt.MoveAction)
+        drag = QtGui.QDrag(self.window())
+
+        mime = QtCore.QMimeData()
+        mime.setData(
+            "application/x-pydidas-plugin-id",
+            QtCore.QByteArray(str(self.widget_id).encode("utf-8")),
+        )
+        drag.setMimeData(mime)
+
+        pixmap = self.grab()
+        drag.setPixmap(pixmap)
+        drag.setHotSpot(pixmap.rect().center())
+
+        (getattr(drag, "exec", None) or drag.exec_)(QtCore.Qt.MoveAction)
 
     def dragEnterEvent(self, event: QtCore.QEvent):
         """
@@ -312,12 +320,21 @@ class PluginInWorkflowBox(CreateWidgetsMixIn, QFrame):
 
         Parameters
         ----------
-        event : QtCore.QEvent
+        event : QtGui.QDropEvent
             The drop event.
         """
-        _source_widget = event.source()
-        event.accept()
-        self.sig_new_node_parent_request.emit(_source_widget.widget_id, self.widget_id)
+        source_id = None
+        if event.mimeData().hasFormat("application/x-pydidas-plugin-id"):
+            raw_id = bytes(
+                event.mimeData().data("application/x-pydidas-plugin-id")
+            ).decode("utf-8")
+            source_id = int(raw_id) if raw_id.isdigit() else raw_id
+        elif hasattr(event.source(), "widget_id"):
+            source_id = event.source().widget_id
+
+        if source_id is not None:
+            self.sig_new_node_parent_request.emit(source_id, self.widget_id)
+            event.acceptProposedAction()
 
     @QtCore.Slot(QtCore.QPoint)
     def _open_context_menu(self, point: QtCore.QPoint):


### PR DESCRIPTION
This PR fixes #190 (the crash that occurs when using Wayland with Qt6 and trying to move nodes around in the workflow editor). It maintains compatibility with X11 and Qt5